### PR TITLE
GuildEvents added

### DIFF
--- a/.github/UPCOMING.md
+++ b/.github/UPCOMING.md
@@ -13,5 +13,5 @@
 - Guild Recruitment
 - Open API to interact with your Discord Server via Sia
 - Enhanced Music Commands / User playlists
-- Guild Events (Scheduled Events)
+- Guild Events (Scheduled Events) - FINISHED
 - 

--- a/.jhipster/GuildEvent.json
+++ b/.jhipster/GuildEvent.json
@@ -1,0 +1,58 @@
+{
+    "fluentMethods": true,
+    "clientRootFolder": "",
+    "relationships": [
+        {
+            "relationshipType": "many-to-one",
+            "otherEntityName": "guildSettings",
+            "otherEntityRelationshipName": "guildevent",
+            "relationshipName": "guildsettings",
+            "otherEntityField": "id"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "eventName",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required",
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "250"
+        },
+        {
+            "fieldName": "eventImageUrl",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required",
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "250"
+        },
+        {
+            "fieldName": "eventMessage",
+            "fieldType": "byte[]",
+            "fieldTypeBlobContent": "text",
+            "fieldValidateRules": [
+                "required",
+                "maxlength"
+            ],
+            "fieldValidateRulesMaxlength": "1500"
+        },
+        {
+            "fieldName": "eventStart",
+            "fieldType": "Instant",
+            "fieldValidateRules": [
+                "required"
+            ]
+        }
+    ],
+    "changelogDate": "20190410175650",
+    "dto": "no",
+    "searchEngine": false,
+    "service": "serviceImpl",
+    "entityTableName": "guild_event",
+    "databaseType": "sql",
+    "jpaMetamodelFiltering": true,
+    "pagination": "pagination"
+}

--- a/.jhipster/GuildSettings.json
+++ b/.jhipster/GuildSettings.json
@@ -15,6 +15,13 @@
             "relationshipType": "one-to-many",
             "otherEntityRelationshipName": "guildsettings",
             "otherEntityRelationshipNameUndefined": false
+        },
+        {
+            "relationshipType": "one-to-many",
+            "otherEntityName": "guildEvent",
+            "otherEntityRelationshipName": "guildsettings",
+            "otherEntityRelationshipNameUndefined": false,
+            "relationshipName": "guildevent"
         }
     ],
     "fields": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5231,8 +5231,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5253,14 +5252,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5275,20 +5272,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5405,8 +5399,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5418,7 +5411,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5433,7 +5425,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5441,14 +5432,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5467,7 +5456,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5548,8 +5536,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5561,7 +5548,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5647,8 +5633,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5684,7 +5669,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5704,7 +5688,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5748,14 +5731,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/main/java/com/trievosoftware/application/domain/GuildEvent.java
+++ b/src/main/java/com/trievosoftware/application/domain/GuildEvent.java
@@ -1,0 +1,206 @@
+package com.trievosoftware.application.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.trievosoftware.discord.utils.FormatUtil;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Message;
+import net.dv8tion.jda.core.entities.User;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.*;
+import javax.validation.constraints.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A GuildEvent.
+ */
+@Entity
+@Table(name = "guild_event")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+public class GuildEvent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
+    @SequenceGenerator(name = "sequenceGenerator")
+    private Long id;
+
+    @NotNull
+    @Size(max = 250)
+    @Column(name = "event_name", length = 250, nullable = false)
+    private String eventName;
+
+    @NotNull
+    @Size(max = 250)
+    @Column(name = "event_image_url", length = 250, nullable = false)
+    private String eventImageUrl;
+
+
+    @Lob
+    @Column(name = "event_message", nullable = false)
+    private String eventMessage;
+
+    @NotNull
+    @Column(name = "event_start", nullable = false)
+    private Instant eventStart;
+
+    @Column(name = "expired", nullable = false)
+    private Boolean expired;
+
+    @ManyToOne
+    @JsonIgnoreProperties("guildevents")
+    private GuildSettings guildsettings;
+
+    public GuildEvent(@NotNull @Size(max = 250) String eventName, @NotNull @Size(max = 250) String eventImageUrl,
+                      String eventMessage, @NotNull Instant eventStart, GuildSettings guildsettings) {
+        this.eventName = eventName;
+        this.eventImageUrl = eventImageUrl;
+        this.eventMessage = eventMessage;
+        this.eventStart = eventStart;
+        this.guildsettings = guildsettings;
+        this.expired = false;
+    }
+
+    public GuildEvent(@NotNull @Size(max = 250) String eventName, @NotNull @Size(max = 250) String eventImageUrl,
+                      String eventMessage, @NotNull Instant eventStart) {
+        this.eventName = eventName;
+        this.eventImageUrl = eventImageUrl;
+        this.eventMessage = eventMessage;
+        this.eventStart = eventStart;
+        this.expired = false;
+    }
+
+    public GuildEvent() {
+    }
+
+    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+
+    public GuildEvent eventName(String eventName) {
+        this.eventName = eventName;
+        return this;
+    }
+
+    public void setEventName(String eventName) {
+        this.eventName = eventName;
+    }
+
+    public String getEventImageUrl() {
+        return eventImageUrl;
+    }
+
+    public GuildEvent eventImageUrl(String eventImageUrl) {
+        this.eventImageUrl = eventImageUrl;
+        return this;
+    }
+
+    public void setEventImageUrl(String eventImageUrl) {
+        this.eventImageUrl = eventImageUrl;
+    }
+
+    public String getEventMessage() {
+        return eventMessage;
+    }
+
+    public GuildEvent eventMessage(String eventMessage) {
+        this.eventMessage = eventMessage;
+        return this;
+    }
+
+    public void setEventMessage(String eventMessage) {
+        this.eventMessage = eventMessage;
+    }
+
+    public Instant getEventStart() {
+        return eventStart;
+    }
+
+    public GuildEvent eventStart(Instant eventStart) {
+        this.eventStart = eventStart;
+        return this;
+    }
+
+    public void setEventStart(Instant eventStart) {
+        this.eventStart = eventStart;
+    }
+
+    public GuildEvent expired(Boolean expired)
+    {
+        this.expired = expired;
+        return this;
+    }
+
+    public Boolean isExpired() {
+        return expired;
+    }
+
+    public void setExpired(Boolean expired) {
+        this.expired = expired;
+    }
+
+    public GuildSettings getGuildsettings() {
+        return guildsettings;
+    }
+
+    public GuildEvent guildsettings(GuildSettings guildSettings) {
+        this.guildsettings = guildSettings;
+        return this;
+    }
+
+    public void setGuildsettings(GuildSettings guildSettings) {
+        this.guildsettings = guildSettings;
+    }
+    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
+
+    public Message getGuildEventMessage(Guild guild)
+    {
+        return FormatUtil.formatGuildEvent(guild, this, false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GuildEvent guildEvent = (GuildEvent) o;
+        if (guildEvent.getId() == null || getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), guildEvent.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
+    }
+
+    @Override
+    public String toString() {
+        return "GuildEvent{" +
+            "id=" + getId() +
+            ", eventName='" + getEventName() + "'" +
+            ", eventImageUrl='" + getEventImageUrl() + "'" +
+            ", eventMessage='" + getEventMessage() + "'" +
+            ", eventStart='" + getEventStart() + "'" +
+            "}";
+    }
+}

--- a/src/main/java/com/trievosoftware/application/domain/GuildEvent.java
+++ b/src/main/java/com/trievosoftware/application/domain/GuildEvent.java
@@ -168,9 +168,9 @@ public class GuildEvent implements Serializable {
     }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
-    public Message getGuildEventMessage(Guild guild)
+    public Message getGuildEventMessage(Guild guild, Boolean sample)
     {
-        return FormatUtil.formatGuildEvent(guild, this, false);
+        return FormatUtil.formatGuildEvent(guild, this, false, sample);
     }
 
     @Override

--- a/src/main/java/com/trievosoftware/application/domain/GuildSettings.java
+++ b/src/main/java/com/trievosoftware/application/domain/GuildSettings.java
@@ -82,6 +82,10 @@ public class GuildSettings implements Serializable {
     @OneToMany(mappedBy = "guildsettings", fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<CustomCommand> customcommands = new HashSet<>();
+
+    @OneToMany(mappedBy = "guildsettings")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<GuildEvent> guildevents = new HashSet<>();
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
     public GuildSettings () {}
@@ -297,8 +301,29 @@ public class GuildSettings implements Serializable {
         return this;
     }
 
-    public void setCustomcommands(Set<CustomCommand> customCommands) {
-        this.customcommands = customCommands;
+    public Set<GuildEvent> getGuildevents() {
+        return guildevents;
+    }
+
+    public GuildSettings guildevents(Set<GuildEvent> guildEvents) {
+        this.guildevents = guildEvents;
+        return this;
+    }
+
+    public GuildSettings addGuildevent(GuildEvent guildEvent) {
+        this.guildevents.add(guildEvent);
+        guildEvent.setGuildsettings(this);
+        return this;
+    }
+
+    public GuildSettings removeGuildevent(GuildEvent guildEvent) {
+        this.guildevents.remove(guildEvent);
+        guildEvent.setGuildsettings(null);
+        return this;
+    }
+
+    public void setGuildevents(Set<GuildEvent> guildEvents) {
+        this.guildevents = guildEvents;
     }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 

--- a/src/main/java/com/trievosoftware/application/exceptions/GuildEventException.java
+++ b/src/main/java/com/trievosoftware/application/exceptions/GuildEventException.java
@@ -1,0 +1,24 @@
+package com.trievosoftware.application.exceptions;
+
+public class GuildEventException extends Exception
+{
+    public static class NoGuildEventFound extends Throwable
+    {
+        public NoGuildEventFound(String errorMessage) {
+            super(errorMessage);
+        }
+        public NoGuildEventFound(String errorMessage, Throwable err) {
+            super(errorMessage, err);
+        }
+    }
+
+    public static class IncorrectGuildEventParamsException extends Throwable
+    {
+        public IncorrectGuildEventParamsException(String errorMessage) {
+            super(errorMessage);
+        }
+        public IncorrectGuildEventParamsException(String errorMessage, Throwable err) {
+            super(errorMessage, err);
+        }
+    }
+}

--- a/src/main/java/com/trievosoftware/application/repository/GuildEventRepository.java
+++ b/src/main/java/com/trievosoftware/application/repository/GuildEventRepository.java
@@ -1,0 +1,25 @@
+package com.trievosoftware.application.repository;
+
+import com.trievosoftware.application.domain.GuildEvent;
+import com.trievosoftware.application.domain.GuildSettings;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * Spring Data  repository for the GuildEvent entity.
+ */
+@SuppressWarnings("unused")
+@Repository
+public interface GuildEventRepository extends JpaRepository<GuildEvent, Long>, JpaSpecificationExecutor<GuildEvent> {
+    List<GuildEvent> findAllByGuildsettings(GuildSettings guildSettings);
+    List<GuildEvent> findAllByEventStartLessThan(Instant now);
+    List<GuildEvent> findAllByGuildsettingsAndEventStartLessThan(GuildSettings guildSettings, Instant now);
+    List<GuildEvent> findAllByGuildsettingsAndExpired(GuildSettings guildSettings, Boolean expired);
+    List<GuildEvent> findAllByExpired(Boolean isExpired);
+    Optional<GuildEvent> findByGuildsettingsAndEventName(GuildSettings guildSettings, String eventName);
+}

--- a/src/main/java/com/trievosoftware/application/service/GuildEventQueryService.java
+++ b/src/main/java/com/trievosoftware/application/service/GuildEventQueryService.java
@@ -1,0 +1,98 @@
+package com.trievosoftware.application.service;
+
+import java.util.List;
+
+import javax.persistence.criteria.JoinType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.jhipster.service.QueryService;
+
+import com.trievosoftware.application.domain.GuildEvent;
+import com.trievosoftware.application.domain.*; // for static metamodels
+import com.trievosoftware.application.repository.GuildEventRepository;
+import com.trievosoftware.application.service.dto.GuildEventCriteria;
+
+/**
+ * Service for executing complex queries for GuildEvent entities in the database.
+ * The main input is a {@link GuildEventCriteria} which gets converted to {@link Specification},
+ * in a way that all the filters must apply.
+ * It returns a {@link List} of {@link GuildEvent} or a {@link Page} of {@link GuildEvent} which fulfills the criteria.
+ */
+@Service
+@Transactional(readOnly = true)
+public class GuildEventQueryService extends QueryService<GuildEvent> {
+
+    private final Logger log = LoggerFactory.getLogger(GuildEventQueryService.class);
+
+    private final GuildEventRepository guildEventRepository;
+
+    public GuildEventQueryService(GuildEventRepository guildEventRepository) {
+        this.guildEventRepository = guildEventRepository;
+    }
+
+    /**
+     * Return a {@link List} of {@link GuildEvent} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public List<GuildEvent> findByCriteria(GuildEventCriteria criteria) {
+        log.debug("find by criteria : {}", criteria);
+        final Specification<GuildEvent> specification = createSpecification(criteria);
+        return guildEventRepository.findAll(specification);
+    }
+
+    /**
+     * Return a {@link Page} of {@link GuildEvent} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @param page The page, which should be returned.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public Page<GuildEvent> findByCriteria(GuildEventCriteria criteria, Pageable page) {
+        log.debug("find by criteria : {}, page: {}", criteria, page);
+        final Specification<GuildEvent> specification = createSpecification(criteria);
+        return guildEventRepository.findAll(specification, page);
+    }
+
+    /**
+     * Return the number of matching entities in the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @return the number of matching entities.
+     */
+    @Transactional(readOnly = true)
+    public long countByCriteria(GuildEventCriteria criteria) {
+        log.debug("count by criteria : {}", criteria);
+        final Specification<GuildEvent> specification = createSpecification(criteria);
+        return guildEventRepository.count(specification);
+    }
+
+    /**
+     * Function to convert GuildEventCriteria to a {@link Specification}
+     */
+    private Specification<GuildEvent> createSpecification(GuildEventCriteria criteria) {
+        Specification<GuildEvent> specification = Specification.where(null);
+        if (criteria != null) {
+            if (criteria.getId() != null) {
+                specification = specification.and(buildSpecification(criteria.getId(), GuildEvent_.id));
+            }
+            if (criteria.getEventName() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getEventName(), GuildEvent_.eventName));
+            }
+            if (criteria.getEventImageUrl() != null) {
+                specification = specification.and(buildStringSpecification(criteria.getEventImageUrl(), GuildEvent_.eventImageUrl));
+            }
+            if (criteria.getEventStart() != null) {
+                specification = specification.and(buildRangeSpecification(criteria.getEventStart(), GuildEvent_.eventStart));
+            }
+        }
+        return specification;
+    }
+}

--- a/src/main/java/com/trievosoftware/application/service/GuildEventService.java
+++ b/src/main/java/com/trievosoftware/application/service/GuildEventService.java
@@ -1,0 +1,77 @@
+package com.trievosoftware.application.service;
+
+import com.trievosoftware.application.domain.GuildEvent;
+
+import com.trievosoftware.application.domain.GuildSettings;
+import com.trievosoftware.application.exceptions.GuildEventException;
+import com.trievosoftware.application.exceptions.InvalidTimeUnitException;
+import com.trievosoftware.application.exceptions.NonTimeInputException;
+import com.trievosoftware.application.exceptions.StringNotIntegerException;
+import net.dv8tion.jda.core.JDA;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service Interface for managing GuildEvent.
+ */
+public interface GuildEventService {
+
+    /**
+     * Save a guildEvent.
+     *
+     * @param guildEvent the entity to save
+     * @return the persisted entity
+     */
+    GuildEvent save(GuildEvent guildEvent);
+
+    /**
+     * Get all the guildEvents.
+     *
+     * @param pageable the pagination information
+     * @return the list of entities
+     */
+    Page<GuildEvent> findAll(Pageable pageable);
+
+
+    /**
+     * Get the "id" guildEvent.
+     *
+     * @param id the id of the entity
+     * @return the entity
+     */
+    Optional<GuildEvent> findOne(Long id);
+
+    /**
+     * Delete the "id" guildEvent.
+     *
+     * @param id the id of the entity
+     */
+    void delete(Long id);
+
+    List<GuildEvent> getEventsForGuild(GuildSettings settings);
+
+    List<GuildEvent> findAllByEventStartLessThan(Instant now);
+
+    List<GuildEvent> findAllByGuildsettingsAndEventStartLessThan(GuildSettings settings, Instant now);
+
+    List<GuildEvent> findAllByGuildSettingsAndExpired(GuildSettings guildSettings, boolean isExpired);
+
+//    GuildEvent getGuildEvent(GuildSettings settings, String eventName) throws GuildEventException.NoGuildEventFound;
+
+    void createGuildEvent(GuildEvent guildEvent);
+
+    GuildEvent getGuildEvent(Long id) throws GuildEventException.NoGuildEventFound;
+
+    GuildEvent generateGuildEvent(GuildSettings guildSettings, String eventName, String eventMessage,
+                                  String eventImageUrl, String eventStartStr)
+        throws InvalidTimeUnitException, StringNotIntegerException, NonTimeInputException,
+                GuildEventException.IncorrectGuildEventParamsException;
+
+    void checkExpiredGuildEvents(JDA jda);
+
+    void cleanExpiredGuildEvents();
+}

--- a/src/main/java/com/trievosoftware/application/service/ServiceManagers.java
+++ b/src/main/java/com/trievosoftware/application/service/ServiceManagers.java
@@ -42,6 +42,7 @@ public class ServiceManagers {
     private GuildRolesService guildRolesService;
     private CustomCommandService customCommandService;
     private IEXService iexService;
+    private GuildEventService guildEventService;
 
     private GuildSettingsServiceImpl guildSettingsServiceImpl;
 
@@ -54,7 +55,7 @@ public class ServiceManagers {
                            PlaylistService playlistService, SongService songService, PollService pollService,
                            PollItemsService pollItemsService, DiscordUserService discordUserService,
                            WelcomeMessageService welcomeMessageService, GuildRolesService guildRolesService,
-                           CustomCommandService customCommandService, IEXService iexService) {
+                           CustomCommandService customCommandService, IEXService iexService, GuildEventService guildEventService) {
         this.actionsService = actionsService;
         this.auditCacheService = auditCacheService;
         this.autoModService = autoModService;
@@ -77,6 +78,7 @@ public class ServiceManagers {
         this.guildRolesService = guildRolesService;
         this.customCommandService = customCommandService;
         this.iexService = iexService;
+        this.guildEventService = guildEventService;
     }
 
     public ActionsService getActionsService() {
@@ -150,4 +152,8 @@ public class ServiceManagers {
     public GuildRolesService guildRolesService() { return guildRolesService; }
 
     public IEXService getIexService() { return iexService; }
+
+    public GuildEventService getGuildEventService() {
+        return guildEventService;
+    }
 }

--- a/src/main/java/com/trievosoftware/application/service/dto/GuildEventCriteria.java
+++ b/src/main/java/com/trievosoftware/application/service/dto/GuildEventCriteria.java
@@ -1,0 +1,103 @@
+package com.trievosoftware.application.service.dto;
+
+import java.io.Serializable;
+import java.util.Objects;
+import io.github.jhipster.service.filter.BooleanFilter;
+import io.github.jhipster.service.filter.DoubleFilter;
+import io.github.jhipster.service.filter.Filter;
+import io.github.jhipster.service.filter.FloatFilter;
+import io.github.jhipster.service.filter.IntegerFilter;
+import io.github.jhipster.service.filter.LongFilter;
+import io.github.jhipster.service.filter.StringFilter;
+import io.github.jhipster.service.filter.InstantFilter;
+
+/**
+ * Criteria class for the GuildEvent entity. This class is used in GuildEventResource to
+ * receive all the possible filtering options from the Http GET request parameters.
+ * For example the following could be a valid requests:
+ * <code> /guild-events?id.greaterThan=5&amp;attr1.contains=something&amp;attr2.specified=false</code>
+ * As Spring is unable to properly convert the types, unless specific {@link Filter} class are used, we need to use
+ * fix type specific filters.
+ */
+public class GuildEventCriteria implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private LongFilter id;
+
+    private StringFilter eventName;
+
+    private StringFilter eventImageUrl;
+
+    private InstantFilter eventStart;
+
+    public LongFilter getId() {
+        return id;
+    }
+
+    public void setId(LongFilter id) {
+        this.id = id;
+    }
+
+    public StringFilter getEventName() {
+        return eventName;
+    }
+
+    public void setEventName(StringFilter eventName) {
+        this.eventName = eventName;
+    }
+
+    public StringFilter getEventImageUrl() {
+        return eventImageUrl;
+    }
+
+    public void setEventImageUrl(StringFilter eventImageUrl) {
+        this.eventImageUrl = eventImageUrl;
+    }
+
+    public InstantFilter getEventStart() {
+        return eventStart;
+    }
+
+    public void setEventStart(InstantFilter eventStart) {
+        this.eventStart = eventStart;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final GuildEventCriteria that = (GuildEventCriteria) o;
+        return
+            Objects.equals(id, that.id) &&
+            Objects.equals(eventName, that.eventName) &&
+            Objects.equals(eventImageUrl, that.eventImageUrl) &&
+            Objects.equals(eventStart, that.eventStart);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+        id,
+        eventName,
+        eventImageUrl,
+        eventStart
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "GuildEventCriteria{" +
+                (id != null ? "id=" + id + ", " : "") +
+                (eventName != null ? "eventName=" + eventName + ", " : "") +
+                (eventImageUrl != null ? "eventImageUrl=" + eventImageUrl + ", " : "") +
+                (eventStart != null ? "eventStart=" + eventStart + ", " : "") +
+            "}";
+    }
+
+}

--- a/src/main/java/com/trievosoftware/application/service/impl/GuildEventServiceImpl.java
+++ b/src/main/java/com/trievosoftware/application/service/impl/GuildEventServiceImpl.java
@@ -1,0 +1,316 @@
+package com.trievosoftware.application.service.impl;
+
+import com.trievosoftware.application.domain.GuildSettings;
+import com.trievosoftware.application.exceptions.GuildEventException;
+import com.trievosoftware.application.exceptions.InvalidTimeUnitException;
+import com.trievosoftware.application.exceptions.NonTimeInputException;
+import com.trievosoftware.application.exceptions.StringNotIntegerException;
+import com.trievosoftware.application.service.GuildEventService;
+import com.trievosoftware.application.domain.GuildEvent;
+import com.trievosoftware.application.repository.GuildEventRepository;
+import com.trievosoftware.discord.utils.*;
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.Guild;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service Implementation for managing GuildEvent.
+ */
+@Service
+@Transactional
+public class GuildEventServiceImpl implements GuildEventService {
+
+    private final Logger log = LoggerFactory.getLogger(GuildEventServiceImpl.class);
+
+    private final GuildEventRepository guildEventRepository;
+
+    public GuildEventServiceImpl(GuildEventRepository guildEventRepository) {
+        this.guildEventRepository = guildEventRepository;
+    }
+
+    /**
+     * Save a guildEvent.
+     *
+     * @param guildEvent the entity to save
+     * @return the persisted entity
+     */
+    @Override
+    public GuildEvent save(GuildEvent guildEvent) {
+        log.debug("Request to save GuildEvent : {}", guildEvent);
+        return guildEventRepository.save(guildEvent);
+    }
+
+    /**
+     * Get all the guildEvents.
+     *
+     * @param pageable the pagination information
+     * @return the list of entities
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<GuildEvent> findAll(Pageable pageable) {
+        log.debug("Request to get all GuildEvents");
+        return guildEventRepository.findAll(pageable);
+    }
+
+
+    /**
+     * Get one guildEvent by id.
+     *
+     * @param id the id of the entity
+     * @return the entity
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<GuildEvent> findOne(Long id) {
+        log.debug("Request to get GuildEvent : {}", id);
+        return guildEventRepository.findById(id);
+    }
+
+    /**
+     * Delete the guildEvent by id.
+     *
+     * @param id the id of the entity
+     */
+    @Override
+    public void delete(Long id) {
+        log.debug("Request to delete GuildEvent : {}", id);
+        guildEventRepository.deleteById(id);
+    }
+
+    /**
+     * Gets all Guild Events for a guild
+     * @param settings a guild's settings
+     * @return List
+     */
+    @Override
+    public List<GuildEvent> getEventsForGuild(GuildSettings settings)
+    {
+        log.debug("Request to get all GuildEvents for Guild={}", settings.getGuildId());
+        return guildEventRepository.findAllByGuildsettings(settings);
+    }
+
+    /**
+     * Gets all Guild events which are expired
+     *
+     * @param now Current Time
+     * @return List
+     */
+    @Override
+    public List<GuildEvent> findAllByEventStartLessThan(Instant now)
+    {
+        log.debug("Request to find all expired GuildEvents");
+        return guildEventRepository.findAllByEventStartLessThan(now);
+    }
+
+    /**
+     * Gets all Expired GuildEvents for a Guild
+     *
+     * @param settings Settings for a Guild
+     * @param now Current Time
+     * @return List
+     */
+    @Override
+    public List<GuildEvent> findAllByGuildsettingsAndEventStartLessThan(GuildSettings settings, Instant now)
+    {
+        log.debug("Request to find all expired GuildEvents for Guild={}", settings.getGuildId());
+        return guildEventRepository.findAllByGuildsettingsAndEventStartLessThan(settings, now);
+    }
+
+    /**
+     * Gets all GuildEvents for a Guild
+     *
+     * @param guildSettings Settings for Guild
+     * @param isExpired Whether the Event has expired or not
+     * @return List
+     */
+    @Override
+    public List<GuildEvent> findAllByGuildSettingsAndExpired(GuildSettings guildSettings, boolean isExpired)
+    {
+        log.debug("Requeest to find all GuildEvents for Guild={}", guildSettings.getGuildId());
+        return guildEventRepository.findAllByGuildsettingsAndExpired(guildSettings, isExpired);
+    }
+
+//    /**
+//     * Gets a GuildEvent by it's Guild and Name
+//     *
+//     * @param settings Settings for Guild
+//     * @param eventName
+//     * @return
+//     * @throws GuildEventException.NoGuildEventFound
+//     */
+//    @Override
+//    public GuildEvent getGuildEvent(GuildSettings settings, String eventName) throws GuildEventException.NoGuildEventFound {
+//        log.debug("Request to get GuildEvent={} for Guild={}", eventName, settings.getGuildId());
+//
+//        Optional<GuildEvent> guildEvent = guildEventRepository.findByGuildsettingsAndEventName(settings, eventName.toUpperCase());
+//
+//        if ( !guildEvent.isPresent() )
+//            throw new GuildEventException.NoGuildEventFound("No Guild Event `" + eventName + "` was found.");
+//
+//        return guildEvent.get();
+//    }
+
+    /**
+     * Creates a new GuildEvent
+     * @param guildEvent Guild event to save
+     */
+    @Override
+    public void createGuildEvent(GuildEvent guildEvent)
+    {
+        log.debug("Request to create new GuildEvent={}", guildEvent.getEventName());
+        save(guildEvent);
+    }
+
+    /**
+     * Gets a GuildEvent from its ID
+     * @param id ID of saved event
+     * @return GuildEvent
+     * @throws GuildEventException.NoGuildEventFound
+     */
+    @Override
+    public GuildEvent getGuildEvent(Long id) throws GuildEventException.NoGuildEventFound {
+        log.debug("Request to get GuildEvent={}", id);
+        Optional<GuildEvent> guildEvent = findOne(id);
+
+        if ( !guildEvent.isPresent() )
+            throw new GuildEventException.NoGuildEventFound("No Guild Event was found.");
+
+        return guildEvent.get();
+    }
+
+    /**
+     * Generates a Non-Persisted GuildEvent
+     * @param guildSettings Settings for Guild
+     * @param eventName The name (Title) of the event
+     * @param eventMessage The message (Body) of the event
+     * @param eventImageUrl The URL of the image to embed
+     * @param eventStartStr The time which the event starts
+     * @return GuildEvent
+     * @throws InvalidTimeUnitException If a unit of time is not correct
+     * @throws StringNotIntegerException If the timestring has no numeric values
+     * @throws NonTimeInputException No Time given
+     * @throws GuildEventException.IncorrectGuildEventParamsException If any parameters are incorrect
+     */
+    @Override
+    public GuildEvent generateGuildEvent(GuildSettings guildSettings, String eventName, String eventMessage,
+                                         String eventImageUrl, String eventStartStr)
+        throws InvalidTimeUnitException, StringNotIntegerException, NonTimeInputException,
+                GuildEventException.IncorrectGuildEventParamsException
+    {
+        log.debug("Request to create new GuildEvent={} for Guild={}", eventName, guildSettings);
+
+        // format the params
+        eventName = eventName.trim().replaceAll(" ", "_").toUpperCase();
+        Instant eventStart = OtherUtil.getTime(eventStartStr.trim().toUpperCase());
+
+        // Perform validations
+        if ( eventName.length() > 250 )
+            throw new GuildEventException.IncorrectGuildEventParamsException("The title of the event must not be longer than" +
+                " 250 characters. Length of title was `" + eventName.length() + "`");
+        if ( !eventImageUrl.equals("")) {
+            if (eventImageUrl.length() > 250)
+                throw new GuildEventException.IncorrectGuildEventParamsException("The log url for your event is long. " +
+                    "Please shorten the URL using a service like https://bitly.com/");
+            // validate the url
+            Pair<Boolean, String> result = Validate.validateUrl(eventImageUrl);
+            if ( !result.getKey() )
+                throw new GuildEventException.IncorrectGuildEventParamsException(result.getValue());
+        }
+        if ( eventMessage.length() > 1500 )
+            throw new GuildEventException.IncorrectGuildEventParamsException("The message of the event must not be longer than" +
+                " 1500 characters. Length of message was `" + eventMessage.length() + "`");
+
+        return new GuildEvent(eventName, eventImageUrl, eventMessage, eventStart, guildSettings);
+    }
+
+    /**
+     * Sets the expired flag for an Event. So it will not rerun during the ScheduledThread
+     *
+     * @param guildEventId Id of the Event
+     */
+    private void setExpiredFlag(Long guildEventId)
+    {
+        log.debug("Request to expire GuildEvent={}", guildEventId);
+        Optional<GuildEvent> guildEvent = findOne(guildEventId);
+
+        if ( guildEvent.isPresent() )
+        {
+            guildEvent.get().setExpired(true);
+            save(guildEvent.get());
+        }
+    }
+
+    /**
+     * Checks for expired GuildEvent. If one or more are found. Sia will attempt to notify users in the follwing format:
+     *      1. The Guild's default channel
+     *      2. The Guild's owner in a private channel, to notify the Owner to let users know
+     * @param jda
+     */
+    @Override
+    public void checkExpiredGuildEvents(JDA jda)
+    {
+        log.debug("Request to check for expired GuildEvent");
+        List<GuildEvent> guildEvents = findAllByEventStartLessThan(Instant.now());
+
+        for ( GuildEvent guildEvent : guildEvents )
+        {
+            if ( !guildEvent.isExpired() )
+            {
+                Guild guild = jda.getGuildById(guildEvent.getGuildsettings().getGuildId());
+
+                // Attempt to send to a default channel
+                try {
+                    guild.getDefaultChannel().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true)).complete();
+                } catch (NullPointerException e) {
+                    // if No default found, send message in private channel to the owner
+                    guild.getOwner().getUser().openPrivateChannel().complete().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true)).complete();
+                    guild.getOwner().getUser().openPrivateChannel().complete().sendMessage("This message was sent to you here because your server does not have" +
+                        " a default channel set up.").complete();
+                }
+
+                log.info("GuildEvent={} completed, message sent", guildEvent.getEventName());
+
+                // now set the expired flag so we dont notify anyone again
+                setExpiredFlag(guildEvent.getId());
+            }
+        }
+    }
+
+    /**
+     * Checks for expired GuildEvents and removes them from the database.
+     * To ensure we do not bloat the repository with data no longer needed.
+     */
+    @Override
+    public void cleanExpiredGuildEvents()
+    {
+        log.debug("Request to clean expired GuildEvents");
+        Instant now = Instant.now();
+
+        List<GuildEvent> guildEvents = guildEventRepository.findAllByExpired(true);
+
+        int removed = 0;
+        for ( GuildEvent event : guildEvents )
+        {
+            Duration difference = Duration.between( event.getEventStart(), now);
+            if ( difference.toDays() > 14 ) { // clean up all expired events after 2 weeks
+                delete(event.getId());
+                removed++;
+            }
+        }
+
+        if ( removed > 0 )
+            log.info("{} expired GuildEvents were cleaneed", removed);
+    }
+}

--- a/src/main/java/com/trievosoftware/application/service/impl/GuildEventServiceImpl.java
+++ b/src/main/java/com/trievosoftware/application/service/impl/GuildEventServiceImpl.java
@@ -272,10 +272,10 @@ public class GuildEventServiceImpl implements GuildEventService {
 
                 // Attempt to send to a default channel
                 try {
-                    guild.getDefaultChannel().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true)).complete();
+                    guild.getDefaultChannel().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true, false)).complete();
                 } catch (NullPointerException e) {
                     // if No default found, send message in private channel to the owner
-                    guild.getOwner().getUser().openPrivateChannel().complete().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true)).complete();
+                    guild.getOwner().getUser().openPrivateChannel().complete().sendMessage(FormatUtil.formatGuildEvent(guild, guildEvent, true, false)).complete();
                     guild.getOwner().getUser().openPrivateChannel().complete().sendMessage("This message was sent to you here because your server does not have" +
                         " a default channel set up.").complete();
                 }

--- a/src/main/java/com/trievosoftware/application/web/rest/GuildEventResource.java
+++ b/src/main/java/com/trievosoftware/application/web/rest/GuildEventResource.java
@@ -1,0 +1,138 @@
+package com.trievosoftware.application.web.rest;
+import com.trievosoftware.application.domain.GuildEvent;
+import com.trievosoftware.application.service.GuildEventService;
+import com.trievosoftware.application.web.rest.errors.BadRequestAlertException;
+import com.trievosoftware.application.web.rest.util.HeaderUtil;
+import com.trievosoftware.application.web.rest.util.PaginationUtil;
+import com.trievosoftware.application.service.dto.GuildEventCriteria;
+import com.trievosoftware.application.service.GuildEventQueryService;
+import io.github.jhipster.web.util.ResponseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * REST controller for managing GuildEvent.
+ */
+@RestController
+@RequestMapping("/api")
+public class GuildEventResource {
+
+    private final Logger log = LoggerFactory.getLogger(GuildEventResource.class);
+
+    private static final String ENTITY_NAME = "guildEvent";
+
+    private final GuildEventService guildEventService;
+
+    private final GuildEventQueryService guildEventQueryService;
+
+    public GuildEventResource(GuildEventService guildEventService, GuildEventQueryService guildEventQueryService) {
+        this.guildEventService = guildEventService;
+        this.guildEventQueryService = guildEventQueryService;
+    }
+
+    /**
+     * POST  /guild-events : Create a new guildEvent.
+     *
+     * @param guildEvent the guildEvent to create
+     * @return the ResponseEntity with status 201 (Created) and with body the new guildEvent, or with status 400 (Bad Request) if the guildEvent has already an ID
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PostMapping("/guild-events")
+    public ResponseEntity<GuildEvent> createGuildEvent(@Valid @RequestBody GuildEvent guildEvent) throws URISyntaxException {
+        log.debug("REST request to save GuildEvent : {}", guildEvent);
+        if (guildEvent.getId() != null) {
+            throw new BadRequestAlertException("A new guildEvent cannot already have an ID", ENTITY_NAME, "idexists");
+        }
+        GuildEvent result = guildEventService.save(guildEvent);
+        return ResponseEntity.created(new URI("/api/guild-events/" + result.getId()))
+            .headers(HeaderUtil.createEntityCreationAlert(ENTITY_NAME, result.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * PUT  /guild-events : Updates an existing guildEvent.
+     *
+     * @param guildEvent the guildEvent to update
+     * @return the ResponseEntity with status 200 (OK) and with body the updated guildEvent,
+     * or with status 400 (Bad Request) if the guildEvent is not valid,
+     * or with status 500 (Internal Server Error) if the guildEvent couldn't be updated
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @PutMapping("/guild-events")
+    public ResponseEntity<GuildEvent> updateGuildEvent(@Valid @RequestBody GuildEvent guildEvent) throws URISyntaxException {
+        log.debug("REST request to update GuildEvent : {}", guildEvent);
+        if (guildEvent.getId() == null) {
+            throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
+        }
+        GuildEvent result = guildEventService.save(guildEvent);
+        return ResponseEntity.ok()
+            .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, guildEvent.getId().toString()))
+            .body(result);
+    }
+
+    /**
+     * GET  /guild-events : get all the guildEvents.
+     *
+     * @param pageable the pagination information
+     * @param criteria the criterias which the requested entities should match
+     * @return the ResponseEntity with status 200 (OK) and the list of guildEvents in body
+     */
+    @GetMapping("/guild-events")
+    public ResponseEntity<List<GuildEvent>> getAllGuildEvents(GuildEventCriteria criteria, Pageable pageable) {
+        log.debug("REST request to get GuildEvents by criteria: {}", criteria);
+        Page<GuildEvent> page = guildEventQueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/guild-events");
+        return ResponseEntity.ok().headers(headers).body(page.getContent());
+    }
+
+    /**
+    * GET  /guild-events/count : count all the guildEvents.
+    *
+    * @param criteria the criterias which the requested entities should match
+    * @return the ResponseEntity with status 200 (OK) and the count in body
+    */
+    @GetMapping("/guild-events/count")
+    public ResponseEntity<Long> countGuildEvents(GuildEventCriteria criteria) {
+        log.debug("REST request to count GuildEvents by criteria: {}", criteria);
+        return ResponseEntity.ok().body(guildEventQueryService.countByCriteria(criteria));
+    }
+
+    /**
+     * GET  /guild-events/:id : get the "id" guildEvent.
+     *
+     * @param id the id of the guildEvent to retrieve
+     * @return the ResponseEntity with status 200 (OK) and with body the guildEvent, or with status 404 (Not Found)
+     */
+    @GetMapping("/guild-events/{id}")
+    public ResponseEntity<GuildEvent> getGuildEvent(@PathVariable Long id) {
+        log.debug("REST request to get GuildEvent : {}", id);
+        Optional<GuildEvent> guildEvent = guildEventService.findOne(id);
+        return ResponseUtil.wrapOrNotFound(guildEvent);
+    }
+
+    /**
+     * DELETE  /guild-events/:id : delete the "id" guildEvent.
+     *
+     * @param id the id of the guildEvent to delete
+     * @return the ResponseEntity with status 200 (OK)
+     */
+    @DeleteMapping("/guild-events/{id}")
+    public ResponseEntity<Void> deleteGuildEvent(@PathVariable Long id) {
+        log.debug("REST request to delete GuildEvent : {}", id);
+        guildEventService.delete(id);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(ENTITY_NAME, id.toString())).build();
+    }
+}

--- a/src/main/java/com/trievosoftware/discord/Listener.java
+++ b/src/main/java/com/trievosoftware/discord/Listener.java
@@ -417,6 +417,10 @@ public class Listener implements EventListener
                 sia.getServiceManagers().getPollService().checkExpiredPolls(event.getJDA()), 0, 30, TimeUnit.SECONDS);
             sia.getThreadpool().scheduleWithFixedDelay(() ->
                 sia.getServiceManagers().getPollService().cleanExpiredPolls(sia.getLogWebhook()), 0, 30, TimeUnit.DAYS);
+            sia.getThreadpool().scheduleWithFixedDelay(() ->
+                sia.getServiceManagers().getGuildEventService().checkExpiredGuildEvents(event.getJDA()), 0 , 1, TimeUnit.MINUTES);
+            sia.getThreadpool().scheduleWithFixedDelay(() ->
+                sia.getServiceManagers().getGuildEventService().cleanExpiredGuildEvents(), 0 , 1, TimeUnit.DAYS);
         }
     }
 }

--- a/src/main/java/com/trievosoftware/discord/Sia.java
+++ b/src/main/java/com/trievosoftware/discord/Sia.java
@@ -161,6 +161,7 @@ public class Sia
                             new PollCommand(this),
                             new WelcomeMessageCommand(this),
                             new CustomCommandCommand(this),
+                            new GuildEventCommand(this),
 
 
                             // Settings

--- a/src/main/java/com/trievosoftware/discord/commands/meta/AbstractModeratorCommand.java
+++ b/src/main/java/com/trievosoftware/discord/commands/meta/AbstractModeratorCommand.java
@@ -59,7 +59,7 @@ public abstract class AbstractModeratorCommand extends Command {
             if(!missingPerms)
                 return true;
             if(event.getMember().getRoles().isEmpty())
-                event.getMessage().addReaction(Constants.ERROR_REACTION).queue();
+                event.replyError("You must have the following permissions to use that: "+listPerms(altPerms));
             else
                 event.replyError("You must have the following permissions to use that: "+listPerms(altPerms));
             return false;

--- a/src/main/java/com/trievosoftware/discord/commands/meta/AbstractModeratorCommand.java
+++ b/src/main/java/com/trievosoftware/discord/commands/meta/AbstractModeratorCommand.java
@@ -18,9 +18,7 @@ package com.trievosoftware.discord.commands.meta;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.trievosoftware.application.exceptions.CustomCommandException;
-import com.trievosoftware.application.exceptions.IncorrectWelcomeMessageParamsException;
-import com.trievosoftware.application.exceptions.NoActiveWelcomeMessage;
+import com.trievosoftware.application.exceptions.*;
 import com.trievosoftware.discord.Constants;
 import com.trievosoftware.discord.Sia;
 import net.dv8tion.jda.core.Permission;
@@ -82,12 +80,13 @@ public abstract class AbstractModeratorCommand extends Command {
             doCommand(event);
         } catch (IncorrectWelcomeMessageParamsException | NoActiveWelcomeMessage |
             CustomCommandException.CommandInvalidParamException | CustomCommandException.CommandExistsException |
-            CustomCommandException.NoCommandExistsException e) {
+            CustomCommandException.NoCommandExistsException | NonTimeInputException | InvalidTimeUnitException |
+            GuildEventException.IncorrectGuildEventParamsException | StringNotIntegerException e) {
             event.replyError(e.getMessage());
         }
     }
 
-    public abstract void doCommand(CommandEvent event) throws IncorrectWelcomeMessageParamsException, NoActiveWelcomeMessage, CustomCommandException.CommandInvalidParamException, CustomCommandException.CommandExistsException, CustomCommandException.NoCommandExistsException;
+    public abstract void doCommand(CommandEvent event) throws IncorrectWelcomeMessageParamsException, NoActiveWelcomeMessage, CustomCommandException.CommandInvalidParamException, CustomCommandException.CommandExistsException, CustomCommandException.NoCommandExistsException, NonTimeInputException, InvalidTimeUnitException, GuildEventException.IncorrectGuildEventParamsException, StringNotIntegerException;
 
     private static String listPerms(Permission... perms)
     {

--- a/src/main/java/com/trievosoftware/discord/commands/moderation/GuildEventCommand.java
+++ b/src/main/java/com/trievosoftware/discord/commands/moderation/GuildEventCommand.java
@@ -9,6 +9,7 @@ import com.trievosoftware.application.domain.GuildSettings;
 import com.trievosoftware.application.exceptions.*;
 import com.trievosoftware.discord.Constants;
 import com.trievosoftware.discord.Sia;
+import com.trievosoftware.discord.commands.meta.AbstractGenericCommand;
 import com.trievosoftware.discord.commands.meta.AbstractModeratorCommand;
 import com.trievosoftware.discord.utils.OtherUtil;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -30,15 +31,15 @@ public class GuildEventCommand extends AbstractModeratorCommand
             "Raid Temple | We will be raiding the Temple on US-EAST server at 7PM Saturday | www.example.com/example.jpg | 5H";
 
     public GuildEventCommand(Sia sia, Permission... altPerms) {
-        super(sia, altPerms);
+        super(sia);
         this.name = "event";
         this.aliases = new String[]{"guildevent"};
         this.help = "Guild Event Commands";
         this.arguments = "create|delete|change";
         this.guildOnly = true;
-        this.children = new AbstractModeratorCommand[]{
-            new CreateGuildEventCommand(sia),
-            new DeleteGuildEventCommand(sia),
+        this.children = new Command[]{
+            new CreateGuildEventCommand(sia, Permission.MANAGE_SERVER),
+            new DeleteGuildEventCommand(sia, Permission.MANAGE_SERVER),
             new ShowGuildEventsCommand(sia)
         };
     }
@@ -95,7 +96,7 @@ public class GuildEventCommand extends AbstractModeratorCommand
             GuildEvent guildEvent = sia.getServiceManagers().getGuildEventService()
                 .generateGuildEvent(guildSettings, eventName, eventMessage, eventImageUrl, timeStr);
 
-            event.reply(guildEvent.getGuildEventMessage(event.getGuild()));
+            event.reply(guildEvent.getGuildEventMessage(event.getGuild(), true));
             waitForConfirmation(event, "Please confirm that the message looks ok", () -> {
                 sia.getServiceManagers().getGuildEventService().createGuildEvent(guildEvent);
                 event.getMessage().delete().complete();
@@ -138,7 +139,7 @@ public class GuildEventCommand extends AbstractModeratorCommand
 
             List<Message> messages = new ArrayList<>();
             for ( GuildEvent message : guildEventList )
-                messages.add(message.getGuildEventMessage(event.getGuild()));
+                messages.add(message.getGuildEventMessage(event.getGuild(), true));
             messages.forEach( message -> event.getTextChannel()
                 .sendMessage(message).queue( sentMsg -> sentMsg.delete().queueAfter(30, TimeUnit.SECONDS)));
 
@@ -168,11 +169,11 @@ public class GuildEventCommand extends AbstractModeratorCommand
         }
     }
 
-    public class ShowGuildEventsCommand extends AbstractModeratorCommand
+    public class ShowGuildEventsCommand extends AbstractGenericCommand
     {
 
-        ShowGuildEventsCommand(Sia sia, Permission... altPerms) {
-            super(sia, altPerms);
+        ShowGuildEventsCommand(Sia sia) {
+            super(sia);
             this.name = "display";
             this.aliases = new String[] {"show"};
             this.help = "Displays saved Guild Events for a Guild/Server";
@@ -200,7 +201,7 @@ public class GuildEventCommand extends AbstractModeratorCommand
 
             List<Message> messages = new ArrayList<>();
             for ( GuildEvent guildEvent : guildEventList )
-                messages.add(guildEvent.getGuildEventMessage(event.getGuild()));
+                messages.add(guildEvent.getGuildEventMessage(event.getGuild(), true));
             messages.forEach( message -> event.getTextChannel()
                 .sendMessage(message).queue( sentMsg -> sentMsg.delete().queueAfter(5, TimeUnit.MINUTES)));
         }

--- a/src/main/java/com/trievosoftware/discord/commands/moderation/GuildEventCommand.java
+++ b/src/main/java/com/trievosoftware/discord/commands/moderation/GuildEventCommand.java
@@ -1,0 +1,226 @@
+package com.trievosoftware.discord.commands.moderation;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.menu.ButtonMenu;
+import com.jagrosh.jdautilities.menu.OrderedMenu;
+import com.trievosoftware.application.domain.GuildEvent;
+import com.trievosoftware.application.domain.GuildSettings;
+import com.trievosoftware.application.exceptions.*;
+import com.trievosoftware.discord.Constants;
+import com.trievosoftware.discord.Sia;
+import com.trievosoftware.discord.commands.meta.AbstractModeratorCommand;
+import com.trievosoftware.discord.utils.OtherUtil;
+import net.dv8tion.jda.core.MessageBuilder;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings("Duplicates")
+public class GuildEventCommand extends AbstractModeratorCommand
+{
+    private final String CANCEL = "\u274C"; // ❌
+    private final String CONFIRM = "\u2611"; // ☑
+    private final String CREATE_HELP =
+        "<event name> | <message> | [message image url] | <time until start>\n\n" +
+            "Raid Temple | We will be raiding the Temple on US-EAST server at 7PM Saturday | www.example.com/example.jpg | 5H";
+
+    public GuildEventCommand(Sia sia, Permission... altPerms) {
+        super(sia, altPerms);
+        this.name = "event";
+        this.aliases = new String[]{"guildevent"};
+        this.help = "Guild Event Commands";
+        this.arguments = "create|delete|change";
+        this.guildOnly = true;
+        this.children = new AbstractModeratorCommand[]{
+            new CreateGuildEventCommand(sia),
+            new DeleteGuildEventCommand(sia),
+            new ShowGuildEventsCommand(sia)
+        };
+    }
+
+    @Override
+    public void doCommand(CommandEvent event)
+    {
+        StringBuilder builder = new StringBuilder(event.getClient().getWarning() + " Guild Poll Commands:\n");
+        for (Command cmd : this.children)
+            builder.append("\n`").append(event.getClient().getPrefix()).append(name).append(" ").append(cmd.getName())
+                .append(" ").append(cmd.getArguments() == null ? "" : cmd.getArguments()).append("` - ").append(cmd.getHelp());
+        event.reply(builder.toString());
+    }
+
+    public class CreateGuildEventCommand extends AbstractModeratorCommand
+    {
+
+        CreateGuildEventCommand(Sia sia, Permission... altPerms) {
+            super(sia, altPerms);
+            this.name = "create";
+            this.aliases = new String[]{"make", "new"};
+            this.help = "Creates a new Guild Event";
+            this.arguments = CREATE_HELP;
+            this.guildOnly = true;
+        }
+
+        @Override
+        public void doCommand(CommandEvent event) throws NonTimeInputException, InvalidTimeUnitException,
+            GuildEventException.IncorrectGuildEventParamsException, StringNotIntegerException
+        {
+            GuildSettings guildSettings =
+                sia.getServiceManagers().getGuildSettingsService().getSettings(event.getGuild());
+            List<GuildEvent> guildEventList =
+                sia.getServiceManagers().getGuildEventService().findAllByGuildSettingsAndExpired(guildSettings, false);
+
+            if ( guildEventList.size() > 4 )
+            {
+                event.reply("You may not have more than 4 active Guild Events. To have more, consider upgrading your Sia plan");
+                return;
+            }
+
+            String[] args = event.getArgs().split("\\|");
+            if (args.length != 4)
+            {
+                event.replyError("A Guild Event must contain: " + CREATE_HELP);
+                return;
+            }
+
+            String eventName        = args[0].trim().replaceAll(" ", "_").toUpperCase();
+            String eventMessage     = args[1].trim();
+            String eventImageUrl    = args[2].trim();
+            String timeStr          = args[3].trim().replaceAll(" ", "").toUpperCase();
+
+            GuildEvent guildEvent = sia.getServiceManagers().getGuildEventService()
+                .generateGuildEvent(guildSettings, eventName, eventMessage, eventImageUrl, timeStr);
+
+            event.reply(guildEvent.getGuildEventMessage(event.getGuild()));
+            waitForConfirmation(event, "Please confirm that the message looks ok", () -> {
+                sia.getServiceManagers().getGuildEventService().createGuildEvent(guildEvent);
+                event.getMessage().delete().complete();
+                event.replySuccess("New Guild Event created and will send a notification to this guild's default channel" +
+                    " at: " + OtherUtil.formatDateTime(event.getGuild(), guildEvent.getEventStart()));
+            });
+        }
+    }
+
+    public class DeleteGuildEventCommand extends AbstractModeratorCommand
+    {
+
+        DeleteGuildEventCommand(Sia sia, Permission... altPerms) {
+            super(sia, altPerms);
+            this.name = "delete";
+            this.aliases = new String[]{"remove"};
+            this.help = "Deletes Guild Event";
+//            this.arguments = "<";
+            this.guildOnly = true;
+        }
+
+        @Override
+        public void doCommand(CommandEvent event)
+        {
+            GuildSettings guildSettings =
+                sia.getServiceManagers().getGuildSettingsService().getSettings(event.getGuild());
+            List<GuildEvent> guildEventList =
+                sia.getServiceManagers().getGuildEventService().findAllByGuildSettingsAndExpired(guildSettings, false);
+
+            if ( guildEventList.size() == 0 )
+            {
+                event.reply("This Guild/Server does not have any active Guild Events");
+                return;
+            }
+
+            Message allMsgMessage = new MessageBuilder()
+                .setContent("Here are all saved Welcome Messages for **" + event.getGuild().getName() + "**").build();
+            event.getTextChannel().sendMessage(allMsgMessage)
+                .queue( sentMsg -> sentMsg.delete().queueAfter(30, TimeUnit.SECONDS));
+
+            List<Message> messages = new ArrayList<>();
+            for ( GuildEvent message : guildEventList )
+                messages.add(message.getGuildEventMessage(event.getGuild()));
+            messages.forEach( message -> event.getTextChannel()
+                .sendMessage(message).queue( sentMsg -> sentMsg.delete().queueAfter(30, TimeUnit.SECONDS)));
+
+            TreeMap<Integer, GuildEvent> guildEventMap = new TreeMap<>();
+            for ( int i = 0; i < guildEventList.size(); i++ )
+                guildEventMap.put(i+1, guildEventList.get(i));
+
+            OrderedMenu.Builder builder = new OrderedMenu.Builder()
+                .setText("Please choose an event to delete")
+                .useNumbers()
+                .useCancelButton(true)
+                .setUsers(event.getAuthor())
+                .setEventWaiter(sia.getEventWaiter())
+                .setSelection((msg, i) ->
+                {
+                    guildEventMap.forEach( (k,v) -> {
+                        if ( k.intValue() == i)
+                            sia.getServiceManagers().getGuildEventService().delete(v.getId());
+                    });
+                    event.reply("Successfully removed Guild Event: `" + guildEventMap.get(i).getEventName() + "` from saved.");
+
+                })
+                .setCancel( (msg) -> {});
+            guildEventMap.forEach( (k,v) -> builder.addChoice(v.getEventName()));
+
+            builder.build().display(event.getTextChannel());
+        }
+    }
+
+    public class ShowGuildEventsCommand extends AbstractModeratorCommand
+    {
+
+        ShowGuildEventsCommand(Sia sia, Permission... altPerms) {
+            super(sia, altPerms);
+            this.name = "display";
+            this.aliases = new String[] {"show"};
+            this.help = "Displays saved Guild Events for a Guild/Server";
+        }
+
+        @Override
+        public void doCommand(CommandEvent event)
+        {
+            GuildSettings guildSettings =
+                sia.getServiceManagers().getGuildSettingsService().getSettings(event.getGuild());
+            List<GuildEvent> guildEventList =
+                sia.getServiceManagers().getGuildEventService().findAllByGuildSettingsAndExpired(guildSettings, false);
+
+            if ( guildEventList.isEmpty() )
+            {
+                event.replyError("This Guild has no active Guild Events");
+                return;
+            }
+
+            Message allMsgMessage = new MessageBuilder()
+                .setContent("Here are all saved Guild Events for **" + event.getGuild().getName() + "**" +
+                    "\nThese messages will automatically disappear in 5 minutes ").build();
+            event.getTextChannel().sendMessage(allMsgMessage)
+                .queue( sentMsg -> sentMsg.delete().queueAfter(5, TimeUnit.MINUTES));
+
+            List<Message> messages = new ArrayList<>();
+            for ( GuildEvent guildEvent : guildEventList )
+                messages.add(guildEvent.getGuildEventMessage(event.getGuild()));
+            messages.forEach( message -> event.getTextChannel()
+                .sendMessage(message).queue( sentMsg -> sentMsg.delete().queueAfter(5, TimeUnit.MINUTES)));
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    private void waitForConfirmation(CommandEvent event, String message,  Runnable confirm)
+    {
+        new ButtonMenu.Builder()
+            .setChoices(CONFIRM, CANCEL)
+            .setEventWaiter(sia.getEventWaiter())
+            .setTimeout(1, TimeUnit.MINUTES)
+
+            .setText(Constants.WARNING + message + "\n\n"+CONFIRM+" Continue\n"+CANCEL+" Cancel")
+            .setFinalAction(m -> m.delete().queue(s->{}, f->{}))
+            .setUsers(event.getAuthor())
+            .setAction(re ->
+            {
+                if(re.getName().equals(CONFIRM))
+                    confirm.run();
+            }).build().display(event.getChannel());
+    }
+}

--- a/src/main/java/com/trievosoftware/discord/utils/FormatUtil.java
+++ b/src/main/java/com/trievosoftware/discord/utils/FormatUtil.java
@@ -17,10 +17,7 @@ package com.trievosoftware.discord.utils;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.trievosoftware.application.domain.CustomCommand;
-import com.trievosoftware.application.domain.Poll;
-import com.trievosoftware.application.domain.PollItems;
-import com.trievosoftware.application.domain.WelcomeMessage;
+import com.trievosoftware.application.domain.*;
 import com.trievosoftware.application.exceptions.StringNotIntegerException;
 import com.trievosoftware.discord.Constants;
 import com.trievosoftware.discord.Sia;
@@ -29,10 +26,13 @@ import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.core.events.guild.member.GuildMemberJoinEvent;
 
 import java.awt.*;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -556,5 +556,40 @@ public class FormatUtil {
         return new MessageBuilder()
             .setEmbed(builder.build())
             .build();
+    }
+
+    public static Message formatGuildEvent(Guild guild, GuildEvent guildEvent, boolean started)
+    {
+
+        EmbedBuilder builder = new EmbedBuilder();
+        MessageBuilder messageBuilder = new MessageBuilder();
+
+        if ( started )
+            messageBuilder.setContent("@everyone \n" + guildEvent.getEventName().replaceAll("_", " ") + " Has started!!!!" );
+        else {
+            Duration diff = Duration.between(Instant.now(), guildEvent.getEventStart());
+            String timeUntil;
+
+            if ( diff.toDays() != 0 )
+                timeUntil = String.format("%d Day(s)", diff.toDays());
+            if ( diff.toHours() != 0 )
+                timeUntil = String.format("%d Hours %02d Minutes",
+                    diff.toHours(),
+                    (Math.abs(diff.getSeconds()) % 3600) / 60);
+            else
+                timeUntil = String.format("%02d Minutes", diff.toMinutes());
+
+            messageBuilder.setContent("@everyone \nREMINDER: `" + guildEvent.getEventName().replaceAll("_", " ") + "` Begins in " +
+                timeUntil);
+        }
+
+        builder.setDescription(guildEvent.getEventMessage());
+        builder.setThumbnail(guildEvent.getEventImageUrl().equals("") ? guild.getIconUrl() : guildEvent.getEventImageUrl());
+
+        if ( !started )
+            builder.setFooter("Start Time: " + OtherUtil.formatDateTime(guild, guildEvent.getEventStart()), null);
+
+        messageBuilder.setEmbed(builder.build());
+        return messageBuilder.build();
     }
 }

--- a/src/main/java/com/trievosoftware/discord/utils/FormatUtil.java
+++ b/src/main/java/com/trievosoftware/discord/utils/FormatUtil.java
@@ -558,14 +558,19 @@ public class FormatUtil {
             .build();
     }
 
-    public static Message formatGuildEvent(Guild guild, GuildEvent guildEvent, boolean started)
+    public static Message formatGuildEvent(Guild guild, GuildEvent guildEvent, boolean started, boolean sample)
     {
 
         EmbedBuilder builder = new EmbedBuilder();
         MessageBuilder messageBuilder = new MessageBuilder();
 
         if ( started )
-            messageBuilder.setContent("@everyone \n" + guildEvent.getEventName().replaceAll("_", " ") + " Has started!!!!" );
+            if ( !sample )
+                messageBuilder.setContent("@everyone \n" + guildEvent.getEventName()
+                    .replaceAll("_", " ") + " Has started!!!!" );
+            else
+                messageBuilder.setContent(guildEvent.getEventName()
+                    .replaceAll("_", " ") + " Has started!!!!" );
         else {
             Duration diff = Duration.between(Instant.now(), guildEvent.getEventStart());
             String timeUntil;
@@ -579,8 +584,12 @@ public class FormatUtil {
             else
                 timeUntil = String.format("%02d Minutes", diff.toMinutes());
 
-            messageBuilder.setContent("@everyone \nREMINDER: `" + guildEvent.getEventName().replaceAll("_", " ") + "` Begins in " +
-                timeUntil);
+            if ( !sample )
+                messageBuilder.setContent("@everyone \nREMINDER: `" + guildEvent.getEventName()
+                    .replaceAll("_", " ") + "` Begins in " + timeUntil);
+            else
+                messageBuilder.setContent("REMINDER: `" + guildEvent.getEventName()
+                    .replaceAll("_", " ") + "` Begins in " + timeUntil);
         }
 
         builder.setDescription(guildEvent.getEventMessage());

--- a/src/main/java/com/trievosoftware/discord/utils/OtherUtil.java
+++ b/src/main/java/com/trievosoftware/discord/utils/OtherUtil.java
@@ -15,6 +15,9 @@
  */
 package com.trievosoftware.discord.utils;
 
+import com.trievosoftware.application.exceptions.InvalidTimeUnitException;
+import com.trievosoftware.application.exceptions.NonTimeInputException;
+import com.trievosoftware.application.exceptions.StringNotIntegerException;
 import com.trievosoftware.discord.Sia;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
@@ -28,8 +31,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -146,5 +156,89 @@ public class OtherUtil
                 roleList.add(sia.getJDA(guild.getIdLong()).getRoleById(roleId));
         }
         return roleList;
+    }
+
+    @SuppressWarnings("Duplicates")
+    public static Instant getTime(String time)
+        throws StringNotIntegerException, InvalidTimeUnitException, NonTimeInputException
+    {
+        int timeLen;
+        try {
+            timeLen = FormatUtil.getMinutes(time);
+            if (timeLen <= 0)
+                throw new NonTimeInputException("Time may not be `0` or a `Negative` number");
+        } catch (StringNotIntegerException e) {
+            LOG.error("{}", e.getMessage());
+            throw new StringNotIntegerException(e.getMessage());
+        }
+
+        String timeType = time.substring(time.length() - 1);
+        switch (timeType) {
+            case "S":
+                return Instant.now().plus(timeLen, ChronoUnit.SECONDS);
+            case "M":
+                return Instant.now().plus(timeLen, ChronoUnit.MINUTES);
+            case "H":
+                return Instant.now().plus(timeLen, ChronoUnit.HOURS);
+            case "D":
+                return Instant.now().plus(timeLen, ChronoUnit.DAYS);
+            default:
+                throw new InvalidTimeUnitException("`" + timeType + "`: Is an invalid Time Type. " +
+                    "Please only use `S (seconds), M (minutes), H (hours), D (days)`");
+        }
+    }
+
+    public static String formatDateTime ( Guild guild, Instant time )
+    {
+        Pair<Locale, ZoneId> localTime = getLocale(guild.getRegion().getName());
+
+        DateTimeFormatter formatter =
+            DateTimeFormatter.ofLocalizedDateTime( FormatStyle.SHORT )
+                .withLocale( localTime.getKey() )
+                .withZone( localTime.getValue() );
+
+        return formatter.format(time) + " " + localTime.getValue().getId();
+    }
+
+    public static Pair<Locale, ZoneId> getLocale(String discordRegion)
+    {
+        Locale local;
+        ZoneId dateTime;
+
+        switch (discordRegion.toUpperCase())
+        {
+            case "AMSTERDAM":
+                local = Locale.GERMANY;
+                dateTime = ZoneId.of("Europe/Paris");
+                break;
+            case "EU CENTRAL":
+                local = Locale.GERMANY;
+                dateTime = ZoneId.of("Europe/Paris");
+                break;
+            case "EU WEST":
+                local = Locale.GERMANY;
+                dateTime = ZoneId.of("Europe/Paris");
+                break;
+            case "FRANKFURT":
+                local = Locale.GERMANY;
+                dateTime = ZoneId.of("Europe/Paris");
+                break;
+            case "HONG KONG":
+                local = Locale.CHINA;
+                dateTime = ZoneId.of("Asia/Shanghai");
+                break;
+            case "JAPAN":
+                local = Locale.JAPAN;
+                dateTime = ZoneId.of("Asia/Tokyo");
+                break;
+            case "LONDON":
+                local = Locale.UK;
+                dateTime = ZoneId.of("Europe/Paris");
+                break;
+            default:
+                local = Locale.US;
+                dateTime = ZoneId.of("America/New_York");
+        }
+        return new Pair<Locale, ZoneId>(local, dateTime);
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20190410175650_added_entity_GuildEvent.xml
+++ b/src/main/resources/config/liquibase/changelog/20190410175650_added_entity_GuildEvent.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <property name="now" value="now()" dbms="h2"/>
+    
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle, mssql"/>
+
+    <!--
+        Added the entity GuildEvent.
+    -->
+    <changeSet id="20190410175650-1" author="jhipster">
+        <createTable tableName="guild_event">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="event_name" type="varchar(250)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="event_image_url" type="varchar(250)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="event_message" type="clob">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="event_start" type="datetime">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="expired" type="boolean">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="guildsettings_id" type="bigint">
+                <constraints nullable="true" />
+            </column>
+
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
+        </createTable>
+        <dropDefaultValue tableName="guild_event" columnName="event_start" columnDataType="datetime"/>
+        
+    </changeSet>
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190410175650_added_entity_constraints_GuildEvent.xml
+++ b/src/main/resources/config/liquibase/changelog/20190410175650_added_entity_constraints_GuildEvent.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <!--
+        Added the constraints for entity GuildEvent.
+    -->
+    <changeSet id="20190410175650-2" author="jhipster">
+
+        <addForeignKeyConstraint baseColumnNames="guildsettings_id"
+                                 baseTableName="guild_event"
+                                 constraintName="fk_guild_event_guildsettings_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="guild_settings"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -23,6 +23,7 @@
     <include file="config/liquibase/changelog/20190326213244_added_entity_WelcomeMessage.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20190403155829_added_entity_GuildRoles.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20190403160322_added_entity_CustomCommand.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190410175650_added_entity_GuildEvent.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="config/liquibase/changelog/20190311195325_added_entity_constraints_GuildMusicSettings.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20190311195327_added_entity_constraints_Songs.xml" relativeToChangelogFile="false"/>
@@ -30,5 +31,6 @@
     <include file="config/liquibase/changelog/20190326213244_added_entity_constraints_WelcomeMessage.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20190403155829_added_entity_constraints_GuildRoles.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20190403160322_added_entity_constraints_CustomCommand.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190410175650_added_entity_constraints_GuildEvent.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/guild-event/guild-event-delete-dialog.tsx
+++ b/src/main/webapp/app/entities/guild-event/guild-event-delete-dialog.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { IGuildEvent } from 'app/shared/model/guild-event.model';
+import { IRootState } from 'app/shared/reducers';
+import { getEntity, deleteEntity } from './guild-event.reducer';
+
+export interface IGuildEventDeleteDialogProps extends StateProps, DispatchProps, RouteComponentProps<{ id: string }> {}
+
+export class GuildEventDeleteDialog extends React.Component<IGuildEventDeleteDialogProps> {
+  componentDidMount() {
+    this.props.getEntity(this.props.match.params.id);
+  }
+
+  confirmDelete = event => {
+    this.props.deleteEntity(this.props.guildEventEntity.id);
+    this.handleClose(event);
+  };
+
+  handleClose = event => {
+    event.stopPropagation();
+    this.props.history.goBack();
+  };
+
+  render() {
+    const { guildEventEntity } = this.props;
+    return (
+      <Modal isOpen toggle={this.handleClose}>
+        <ModalHeader toggle={this.handleClose}>
+          <Translate contentKey="entity.delete.title">Confirm delete operation</Translate>
+        </ModalHeader>
+        <ModalBody id="siaApp.guildEvent.delete.question">
+          <Translate contentKey="siaApp.guildEvent.delete.question" interpolate={{ id: guildEventEntity.id }}>
+            Are you sure you want to delete this GuildEvent?
+          </Translate>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="secondary" onClick={this.handleClose}>
+            <FontAwesomeIcon icon="ban" />
+            &nbsp;
+            <Translate contentKey="entity.action.cancel">Cancel</Translate>
+          </Button>
+          <Button id="jhi-confirm-delete-guildEvent" color="danger" onClick={this.confirmDelete}>
+            <FontAwesomeIcon icon="trash" />
+            &nbsp;
+            <Translate contentKey="entity.action.delete">Delete</Translate>
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = ({ guildEvent }: IRootState) => ({
+  guildEventEntity: guildEvent.entity
+});
+
+const mapDispatchToProps = { getEntity, deleteEntity };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GuildEventDeleteDialog);

--- a/src/main/webapp/app/entities/guild-event/guild-event-detail.tsx
+++ b/src/main/webapp/app/entities/guild-event/guild-event-detail.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { Button, Row, Col } from 'reactstrap';
+// tslint:disable-next-line:no-unused-variable
+import { Translate, ICrudGetAction, byteSize, TextFormat } from 'react-jhipster';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { IRootState } from 'app/shared/reducers';
+import { getEntity } from './guild-event.reducer';
+import { IGuildEvent } from 'app/shared/model/guild-event.model';
+// tslint:disable-next-line:no-unused-variable
+import { APP_DATE_FORMAT, APP_LOCAL_DATE_FORMAT } from 'app/config/constants';
+
+export interface IGuildEventDetailProps extends StateProps, DispatchProps, RouteComponentProps<{ id: string }> {}
+
+export class GuildEventDetail extends React.Component<IGuildEventDetailProps> {
+  componentDidMount() {
+    this.props.getEntity(this.props.match.params.id);
+  }
+
+  render() {
+    const { guildEventEntity } = this.props;
+    return (
+      <Row>
+        <Col md="8">
+          <h2>
+            <Translate contentKey="siaApp.guildEvent.detail.title">GuildEvent</Translate> [<b>{guildEventEntity.id}</b>]
+          </h2>
+          <dl className="jh-entity-details">
+            <dt>
+              <span id="eventName">
+                <Translate contentKey="siaApp.guildEvent.eventName">Event Name</Translate>
+              </span>
+            </dt>
+            <dd>{guildEventEntity.eventName}</dd>
+            <dt>
+              <span id="eventImageUrl">
+                <Translate contentKey="siaApp.guildEvent.eventImageUrl">Event Image Url</Translate>
+              </span>
+            </dt>
+            <dd>{guildEventEntity.eventImageUrl}</dd>
+            <dt>
+              <span id="eventMessage">
+                <Translate contentKey="siaApp.guildEvent.eventMessage">Event Message</Translate>
+              </span>
+            </dt>
+            <dd>{guildEventEntity.eventMessage}</dd>
+            <dt>
+              <span id="eventStart">
+                <Translate contentKey="siaApp.guildEvent.eventStart">Event Start</Translate>
+              </span>
+            </dt>
+            <dd>
+              <TextFormat value={guildEventEntity.eventStart} type="date" format={APP_DATE_FORMAT} />
+            </dd>
+            <dt>
+              <span id="expired">
+                <Translate contentKey="siaApp.guildEvent.expired">Is Expired</Translate>
+              </span>
+            </dt>
+            <dd>{guildEventEntity.expired ? 'true' : 'false'}</dd>
+            <dt>
+              <Translate contentKey="siaApp.guildEvent.guildsettings">Guild Settings</Translate>
+            </dt>
+            <dd>{guildEventEntity.guildsettings ? guildEventEntity.guildsettings.id : ''}</dd>
+          </dl>
+          <Button tag={Link} to="/entity/guild-event" replace color="info">
+            <FontAwesomeIcon icon="arrow-left" />{' '}
+            <span className="d-none d-md-inline">
+              <Translate contentKey="entity.action.back">Back</Translate>
+            </span>
+          </Button>
+          &nbsp;
+          <Button tag={Link} to={`/entity/guild-event/${guildEventEntity.id}/edit`} replace color="primary">
+            <FontAwesomeIcon icon="pencil-alt" />{' '}
+            <span className="d-none d-md-inline">
+              <Translate contentKey="entity.action.edit">Edit</Translate>
+            </span>
+          </Button>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+const mapStateToProps = ({ guildEvent }: IRootState) => ({
+  guildEventEntity: guildEvent.entity
+});
+
+const mapDispatchToProps = { getEntity };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GuildEventDetail);

--- a/src/main/webapp/app/entities/guild-event/guild-event-update.tsx
+++ b/src/main/webapp/app/entities/guild-event/guild-event-update.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { Button, Row, Col, Label } from 'reactstrap';
+import { AvForm, AvGroup, AvInput, AvField } from 'availity-reactstrap-validation';
+// tslint:disable-next-line:no-unused-variable
+import { Translate, translate, ICrudGetAction, ICrudGetAllAction, setFileData, byteSize, ICrudPutAction } from 'react-jhipster';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IRootState } from 'app/shared/reducers';
+
+import { IGuildSettings } from 'app/shared/model/guild-settings.model';
+import { getEntities as getGuildSettings } from 'app/entities/guild-settings/guild-settings.reducer';
+import { getEntity, updateEntity, createEntity, setBlob, reset } from './guild-event.reducer';
+import { IGuildEvent } from 'app/shared/model/guild-event.model';
+// tslint:disable-next-line:no-unused-variable
+import { convertDateTimeFromServer, convertDateTimeToServer } from 'app/shared/util/date-utils';
+import { mapIdList } from 'app/shared/util/entity-utils';
+
+export interface IGuildEventUpdateProps extends StateProps, DispatchProps, RouteComponentProps<{ id: string }> {}
+
+export interface IGuildEventUpdateState {
+  isNew: boolean;
+  guildsettingsId: string;
+}
+
+export class GuildEventUpdate extends React.Component<IGuildEventUpdateProps, IGuildEventUpdateState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      guildsettingsId: '0',
+      isNew: !this.props.match.params || !this.props.match.params.id
+    };
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.updateSuccess !== this.props.updateSuccess && nextProps.updateSuccess) {
+      this.handleClose();
+    }
+  }
+
+  componentDidMount() {
+    if (this.state.isNew) {
+      this.props.reset();
+    } else {
+      this.props.getEntity(this.props.match.params.id);
+    }
+
+    this.props.getGuildSettings();
+  }
+
+  onBlobChange = (isAnImage, name) => event => {
+    setFileData(event, (contentType, data) => this.props.setBlob(name, data, contentType), isAnImage);
+  };
+
+  clearBlob = name => () => {
+    this.props.setBlob(name, undefined, undefined);
+  };
+
+  saveEntity = (event, errors, values) => {
+    values.eventStart = convertDateTimeToServer(values.eventStart);
+
+    if (errors.length === 0) {
+      const { guildEventEntity } = this.props;
+      const entity = {
+        ...guildEventEntity,
+        ...values
+      };
+
+      if (this.state.isNew) {
+        this.props.createEntity(entity);
+      } else {
+        this.props.updateEntity(entity);
+      }
+    }
+  };
+
+  handleClose = () => {
+    this.props.history.push('/entity/guild-event');
+  };
+
+  render() {
+    const { guildEventEntity, guildSettings, loading, updating } = this.props;
+    const { isNew } = this.state;
+
+    const { eventMessage } = guildEventEntity;
+
+    return (
+      <div>
+        <Row className="justify-content-center">
+          <Col md="8">
+            <h2 id="siaApp.guildEvent.home.createOrEditLabel">
+              <Translate contentKey="siaApp.guildEvent.home.createOrEditLabel">Create or edit a GuildEvent</Translate>
+            </h2>
+          </Col>
+        </Row>
+        <Row className="justify-content-center">
+          <Col md="8">
+            {loading ? (
+              <p>Loading...</p>
+            ) : (
+              <AvForm model={isNew ? {} : guildEventEntity} onSubmit={this.saveEntity}>
+                {!isNew ? (
+                  <AvGroup>
+                    <Label for="id">
+                      <Translate contentKey="global.field.id">ID</Translate>
+                    </Label>
+                    <AvInput id="guild-event-id" type="text" className="form-control" name="id" required readOnly />
+                  </AvGroup>
+                ) : null}
+                <AvGroup>
+                  <Label id="eventNameLabel" for="eventName">
+                    <Translate contentKey="siaApp.guildEvent.eventName">Event Name</Translate>
+                  </Label>
+                  <AvField
+                    id="guild-event-eventName"
+                    type="text"
+                    name="eventName"
+                    validate={{
+                      required: { value: true, errorMessage: translate('entity.validation.required') },
+                      maxLength: { value: 250, errorMessage: translate('entity.validation.maxlength', { max: 250 }) }
+                    }}
+                  />
+                </AvGroup>
+                <AvGroup>
+                  <Label id="eventImageUrlLabel" for="eventImageUrl">
+                    <Translate contentKey="siaApp.guildEvent.eventImageUrl">Event Image Url</Translate>
+                  </Label>
+                  <AvField
+                    id="guild-event-eventImageUrl"
+                    type="text"
+                    name="eventImageUrl"
+                    validate={{
+                      required: { value: true, errorMessage: translate('entity.validation.required') },
+                      maxLength: { value: 250, errorMessage: translate('entity.validation.maxlength', { max: 250 }) }
+                    }}
+                  />
+                </AvGroup>
+                <AvGroup>
+                  <Label id="eventMessageLabel" for="eventMessage">
+                    <Translate contentKey="siaApp.guildEvent.eventMessage">Event Message</Translate>
+                  </Label>
+                  <AvInput
+                    id="guild-event-eventMessage"
+                    type="textarea"
+                    name="eventMessage"
+                    validate={{
+                      required: { value: true, errorMessage: translate('entity.validation.required') }
+                    }}
+                  />
+                </AvGroup>
+                <AvGroup>
+                  <Label id="eventStartLabel" for="eventStart">
+                    <Translate contentKey="siaApp.guildEvent.eventStart">Event Start</Translate>
+                  </Label>
+                  <AvInput
+                    id="guild-event-eventStart"
+                    type="datetime-local"
+                    className="form-control"
+                    name="eventStart"
+                    placeholder={'YYYY-MM-DD HH:mm'}
+                    value={isNew ? null : convertDateTimeFromServer(this.props.guildEventEntity.eventStart)}
+                    validate={{
+                      required: { value: true, errorMessage: translate('entity.validation.required') }
+                    }}
+                  />
+                </AvGroup>
+                <AvGroup>
+                  <Label id="expired" check>
+                    <AvInput id="guild-event-expired" type="checkbox" className="form-control" name="expired" />
+                    <Translate contentKey="siaApp.poll.expired">Is Expired</Translate>
+                  </Label>
+                  {/*<AvField id="guild-event-expired" type="boolean" className="form-control" name="expired" />*/}
+                </AvGroup>
+                <AvGroup>
+                  <Label for="guildsettings.id">
+                    <Translate contentKey="siaApp.guildEvent.guildsettings">Guildsettings</Translate>
+                  </Label>
+                  <AvInput id="guild-event-guildsettings" type="select" className="form-control" name="guildsettings.id">
+                    <option value="" key="0" />
+                    {guildSettings
+                      ? guildSettings.map(otherEntity => (
+                          <option value={otherEntity.id} key={otherEntity.id}>
+                            {otherEntity.id}
+                          </option>
+                        ))
+                      : null}
+                  </AvInput>
+                </AvGroup>
+                <Button tag={Link} id="cancel-save" to="/entity/guild-event" replace color="info">
+                  <FontAwesomeIcon icon="arrow-left" />
+                  &nbsp;
+                  <span className="d-none d-md-inline">
+                    <Translate contentKey="entity.action.back">Back</Translate>
+                  </span>
+                </Button>
+                &nbsp;
+                <Button color="primary" id="save-entity" type="submit" disabled={updating}>
+                  <FontAwesomeIcon icon="save" />
+                  &nbsp;
+                  <Translate contentKey="entity.action.save">Save</Translate>
+                </Button>
+              </AvForm>
+            )}
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (storeState: IRootState) => ({
+  guildSettings: storeState.guildSettings.entities,
+  guildEventEntity: storeState.guildEvent.entity,
+  loading: storeState.guildEvent.loading,
+  updating: storeState.guildEvent.updating,
+  updateSuccess: storeState.guildEvent.updateSuccess
+});
+
+const mapDispatchToProps = {
+  getGuildSettings,
+  getEntity,
+  updateEntity,
+  setBlob,
+  createEntity,
+  reset
+};
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GuildEventUpdate);

--- a/src/main/webapp/app/entities/guild-event/guild-event.reducer.ts
+++ b/src/main/webapp/app/entities/guild-event/guild-event.reducer.ts
@@ -1,0 +1,170 @@
+import axios from 'axios';
+import { ICrudGetAction, ICrudGetAllAction, ICrudPutAction, ICrudDeleteAction } from 'react-jhipster';
+
+import { cleanEntity } from 'app/shared/util/entity-utils';
+import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
+
+import { IGuildEvent, defaultValue } from 'app/shared/model/guild-event.model';
+
+export const ACTION_TYPES = {
+  FETCH_GUILDEVENT_LIST: 'guildEvent/FETCH_GUILDEVENT_LIST',
+  FETCH_GUILDEVENT: 'guildEvent/FETCH_GUILDEVENT',
+  CREATE_GUILDEVENT: 'guildEvent/CREATE_GUILDEVENT',
+  UPDATE_GUILDEVENT: 'guildEvent/UPDATE_GUILDEVENT',
+  DELETE_GUILDEVENT: 'guildEvent/DELETE_GUILDEVENT',
+  SET_BLOB: 'guildEvent/SET_BLOB',
+  RESET: 'guildEvent/RESET'
+};
+
+const initialState = {
+  loading: false,
+  errorMessage: null,
+  entities: [] as ReadonlyArray<IGuildEvent>,
+  entity: defaultValue,
+  updating: false,
+  totalItems: 0,
+  updateSuccess: false
+};
+
+export type GuildEventState = Readonly<typeof initialState>;
+
+// Reducer
+
+export default (state: GuildEventState = initialState, action): GuildEventState => {
+  switch (action.type) {
+    case REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST):
+    case REQUEST(ACTION_TYPES.FETCH_GUILDEVENT):
+      return {
+        ...state,
+        errorMessage: null,
+        updateSuccess: false,
+        loading: true
+      };
+    case REQUEST(ACTION_TYPES.CREATE_GUILDEVENT):
+    case REQUEST(ACTION_TYPES.UPDATE_GUILDEVENT):
+    case REQUEST(ACTION_TYPES.DELETE_GUILDEVENT):
+      return {
+        ...state,
+        errorMessage: null,
+        updateSuccess: false,
+        updating: true
+      };
+    case FAILURE(ACTION_TYPES.FETCH_GUILDEVENT_LIST):
+    case FAILURE(ACTION_TYPES.FETCH_GUILDEVENT):
+    case FAILURE(ACTION_TYPES.CREATE_GUILDEVENT):
+    case FAILURE(ACTION_TYPES.UPDATE_GUILDEVENT):
+    case FAILURE(ACTION_TYPES.DELETE_GUILDEVENT):
+      return {
+        ...state,
+        loading: false,
+        updating: false,
+        updateSuccess: false,
+        errorMessage: action.payload
+      };
+    case SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST):
+      return {
+        ...state,
+        loading: false,
+        totalItems: action.payload.headers['x-total-count'],
+        entities: action.payload.data
+      };
+    case SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT):
+      return {
+        ...state,
+        loading: false,
+        entity: action.payload.data
+      };
+    case SUCCESS(ACTION_TYPES.CREATE_GUILDEVENT):
+    case SUCCESS(ACTION_TYPES.UPDATE_GUILDEVENT):
+      return {
+        ...state,
+        updating: false,
+        updateSuccess: true,
+        entity: action.payload.data
+      };
+    case SUCCESS(ACTION_TYPES.DELETE_GUILDEVENT):
+      return {
+        ...state,
+        updating: false,
+        updateSuccess: true,
+        entity: {}
+      };
+    case ACTION_TYPES.SET_BLOB:
+      const { name, data, contentType } = action.payload;
+      return {
+        ...state,
+        entity: {
+          ...state.entity,
+          [name]: data,
+          [name + 'ContentType']: contentType
+        }
+      };
+    case ACTION_TYPES.RESET:
+      return {
+        ...initialState
+      };
+    default:
+      return state;
+  }
+};
+
+const apiUrl = 'api/guild-events';
+
+// Actions
+
+export const getEntities: ICrudGetAllAction<IGuildEvent> = (page, size, sort) => {
+  const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
+  return {
+    type: ACTION_TYPES.FETCH_GUILDEVENT_LIST,
+    payload: axios.get<IGuildEvent>(`${requestUrl}${sort ? '&' : '?'}cacheBuster=${new Date().getTime()}`)
+  };
+};
+
+export const getEntity: ICrudGetAction<IGuildEvent> = id => {
+  const requestUrl = `${apiUrl}/${id}`;
+  return {
+    type: ACTION_TYPES.FETCH_GUILDEVENT,
+    payload: axios.get<IGuildEvent>(requestUrl)
+  };
+};
+
+export const createEntity: ICrudPutAction<IGuildEvent> = entity => async dispatch => {
+  const result = await dispatch({
+    type: ACTION_TYPES.CREATE_GUILDEVENT,
+    payload: axios.post(apiUrl, cleanEntity(entity))
+  });
+  dispatch(getEntities());
+  return result;
+};
+
+export const updateEntity: ICrudPutAction<IGuildEvent> = entity => async dispatch => {
+  const result = await dispatch({
+    type: ACTION_TYPES.UPDATE_GUILDEVENT,
+    payload: axios.put(apiUrl, cleanEntity(entity))
+  });
+  dispatch(getEntities());
+  return result;
+};
+
+export const deleteEntity: ICrudDeleteAction<IGuildEvent> = id => async dispatch => {
+  const requestUrl = `${apiUrl}/${id}`;
+  const result = await dispatch({
+    type: ACTION_TYPES.DELETE_GUILDEVENT,
+    payload: axios.delete(requestUrl)
+  });
+  dispatch(getEntities());
+  return result;
+};
+
+export const setBlob = (name, data, contentType?) => ({
+  type: ACTION_TYPES.SET_BLOB,
+  payload: {
+    name,
+    data,
+    contentType
+  }
+});
+
+export const reset = () => ({
+  type: ACTION_TYPES.RESET
+});

--- a/src/main/webapp/app/entities/guild-event/guild-event.tsx
+++ b/src/main/webapp/app/entities/guild-event/guild-event.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { Button, Col, Row, Table } from 'reactstrap';
+// tslint:disable-next-line:no-unused-variable
+import {
+  byteSize,
+  Translate,
+  ICrudGetAllAction,
+  TextFormat,
+  getSortState,
+  IPaginationBaseState,
+  getPaginationItemsNumber,
+  JhiPagination
+} from 'react-jhipster';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { IRootState } from 'app/shared/reducers';
+import { getEntities } from './guild-event.reducer';
+import { IGuildEvent } from 'app/shared/model/guild-event.model';
+// tslint:disable-next-line:no-unused-variable
+import { APP_DATE_FORMAT, APP_LOCAL_DATE_FORMAT } from 'app/config/constants';
+import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
+
+export interface IGuildEventProps extends StateProps, DispatchProps, RouteComponentProps<{ url: string }> {}
+
+export type IGuildEventState = IPaginationBaseState;
+
+export class GuildEvent extends React.Component<IGuildEventProps, IGuildEventState> {
+  state: IGuildEventState = {
+    ...getSortState(this.props.location, ITEMS_PER_PAGE)
+  };
+
+  componentDidMount() {
+    this.getEntities();
+  }
+
+  sort = prop => () => {
+    this.setState(
+      {
+        order: this.state.order === 'asc' ? 'desc' : 'asc',
+        sort: prop
+      },
+      () => this.sortEntities()
+    );
+  };
+
+  sortEntities() {
+    this.getEntities();
+    this.props.history.push(`${this.props.location.pathname}?page=${this.state.activePage}&sort=${this.state.sort},${this.state.order}`);
+  }
+
+  handlePagination = activePage => this.setState({ activePage }, () => this.sortEntities());
+
+  getEntities = () => {
+    const { activePage, itemsPerPage, sort, order } = this.state;
+    this.props.getEntities(activePage - 1, itemsPerPage, `${sort},${order}`);
+  };
+
+  render() {
+    const { guildEventList, match, totalItems } = this.props;
+    return (
+      <div>
+        <h2 id="guild-event-heading">
+          <Translate contentKey="siaApp.guildEvent.home.title">Guild Events</Translate>
+          <Link to={`${match.url}/new`} className="btn btn-primary float-right jh-create-entity" id="jh-create-entity">
+            <FontAwesomeIcon icon="plus" />
+            &nbsp;
+            <Translate contentKey="siaApp.guildEvent.home.createLabel">Create new Guild Event</Translate>
+          </Link>
+        </h2>
+        <div className="table-responsive">
+          <Table responsive>
+            <thead>
+              <tr>
+                <th className="hand" onClick={this.sort('id')}>
+                  <Translate contentKey="global.field.id">ID</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th className="hand" onClick={this.sort('eventName')}>
+                  <Translate contentKey="siaApp.guildEvent.eventName">Event Name</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th className="hand" onClick={this.sort('eventImageUrl')}>
+                  <Translate contentKey="siaApp.guildEvent.eventImageUrl">Event Image Url</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th className="hand" onClick={this.sort('eventMessage')}>
+                  <Translate contentKey="siaApp.guildEvent.eventMessage">Event Message</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th className="hand" onClick={this.sort('eventStart')}>
+                  <Translate contentKey="siaApp.guildEvent.eventStart">Event Start</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th>
+                  <Translate contentKey="siaApp.guildEvent.expired">Is Expired</Translate>
+                </th>
+                <th>
+                  <Translate contentKey="siaApp.guildEvent.guildsettings">Guild Settings</Translate> <FontAwesomeIcon icon="sort" />
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {guildEventList.map((guildEvent, i) => (
+                <tr key={`entity-${i}`}>
+                  <td>
+                    <Button tag={Link} to={`${match.url}/${guildEvent.id}`} color="link" size="sm">
+                      {guildEvent.id}
+                    </Button>
+                  </td>
+                  <td>{guildEvent.eventName}</td>
+                  <td>{guildEvent.eventImageUrl}</td>
+                  <td>{guildEvent.eventMessage}</td>
+                  <td>
+                    <TextFormat type="date" value={guildEvent.eventStart} format={APP_DATE_FORMAT} />
+                  </td>
+                  <td>{guildEvent.expired}</td>
+                  <td>
+                    {guildEvent.guildsettings ? (
+                      <Link to={`guild-settings/${guildEvent.guildsettings.id}`}>{guildEvent.guildsettings.id}</Link>
+                    ) : (
+                      ''
+                    )}
+                  </td>
+                  <td className="text-right">
+                    <div className="btn-group flex-btn-group-container">
+                      <Button tag={Link} to={`${match.url}/${guildEvent.id}`} color="info" size="sm">
+                        <FontAwesomeIcon icon="eye" />{' '}
+                        <span className="d-none d-md-inline">
+                          <Translate contentKey="entity.action.view">View</Translate>
+                        </span>
+                      </Button>
+                      <Button tag={Link} to={`${match.url}/${guildEvent.id}/edit`} color="primary" size="sm">
+                        <FontAwesomeIcon icon="pencil-alt" />{' '}
+                        <span className="d-none d-md-inline">
+                          <Translate contentKey="entity.action.edit">Edit</Translate>
+                        </span>
+                      </Button>
+                      <Button tag={Link} to={`${match.url}/${guildEvent.id}/delete`} color="danger" size="sm">
+                        <FontAwesomeIcon icon="trash" />{' '}
+                        <span className="d-none d-md-inline">
+                          <Translate contentKey="entity.action.delete">Delete</Translate>
+                        </span>
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </div>
+        <Row className="justify-content-center">
+          <JhiPagination
+            items={getPaginationItemsNumber(totalItems, this.state.itemsPerPage)}
+            activePage={this.state.activePage}
+            onSelect={this.handlePagination}
+            maxButtons={5}
+          />
+        </Row>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = ({ guildEvent }: IRootState) => ({
+  guildEventList: guildEvent.entities,
+  totalItems: guildEvent.totalItems
+});
+
+const mapDispatchToProps = {
+  getEntities
+};
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GuildEvent);

--- a/src/main/webapp/app/entities/guild-event/index.tsx
+++ b/src/main/webapp/app/entities/guild-event/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Switch } from 'react-router-dom';
+
+import ErrorBoundaryRoute from 'app/shared/error/error-boundary-route';
+
+import GuildEvent from './guild-event';
+import GuildEventDetail from './guild-event-detail';
+import GuildEventUpdate from './guild-event-update';
+import GuildEventDeleteDialog from './guild-event-delete-dialog';
+
+const Routes = ({ match }) => (
+  <>
+    <Switch>
+      <ErrorBoundaryRoute exact path={`${match.url}/new`} component={GuildEventUpdate} />
+      <ErrorBoundaryRoute exact path={`${match.url}/:id/edit`} component={GuildEventUpdate} />
+      <ErrorBoundaryRoute exact path={`${match.url}/:id`} component={GuildEventDetail} />
+      <ErrorBoundaryRoute path={match.url} component={GuildEvent} />
+    </Switch>
+    <ErrorBoundaryRoute path={`${match.url}/:id/delete`} component={GuildEventDeleteDialog} />
+  </>
+);
+
+export default Routes;

--- a/src/main/webapp/app/entities/index.tsx
+++ b/src/main/webapp/app/entities/index.tsx
@@ -22,6 +22,7 @@ import DiscordUser from './discord-user';
 import WelcomeMessage from './welcome-message';
 import GuildRoles from './guild-roles';
 import CustomCommand from './custom-command';
+import GuildEvent from './guild-event';
 /* jhipster-needle-add-route-import - JHipster will add routes here */
 
 const Routes = ({ match }) => (
@@ -46,6 +47,7 @@ const Routes = ({ match }) => (
       <ErrorBoundaryRoute path={`${match.url}/welcome-message`} component={WelcomeMessage} />
       <ErrorBoundaryRoute path={`${match.url}/guild-roles`} component={GuildRoles} />
       <ErrorBoundaryRoute path={`${match.url}/custom-command`} component={CustomCommand} />
+      <ErrorBoundaryRoute path={`${match.url}/guild-event`} component={GuildEvent} />
       {/* jhipster-needle-add-route-path - JHipster will routes here */}
     </Switch>
   </div>

--- a/src/main/webapp/app/entities/poll/poll-update.tsx
+++ b/src/main/webapp/app/entities/poll/poll-update.tsx
@@ -158,7 +158,7 @@ export class PollUpdate extends React.Component<IPollUpdateProps, IPollUpdateSta
                     <AvInput id="poll-expired" type="checkbox" className="form-control" name="expired" />
                     <Translate contentKey="siaApp.poll.expired">Is Expired</Translate>
                   </Label>
-                  <AvField id="poll-expired" type="boolean" className="form-control" name="expired" />
+                  {/*<AvField id="poll-expired" type="boolean" className="form-control" name="expired" />*/}
                 </AvGroup>
                 <AvGroup>
                   <Label id="finishTimeLabel" for="finishTime">

--- a/src/main/webapp/app/shared/layout/header/menus/entities.tsx
+++ b/src/main/webapp/app/shared/layout/header/menus/entities.tsx
@@ -98,6 +98,11 @@ export const EntitiesMenu = props => (
       &nbsp;
       <Translate contentKey="global.menu.entities.customCommand" />
     </DropdownItem>
+    <DropdownItem tag={Link} to="/entity/guild-event">
+      <FontAwesomeIcon icon="asterisk" fixedWidth />
+      &nbsp;
+      <Translate contentKey="global.menu.entities.guildEvent" />
+    </DropdownItem>
     {/* jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here */}
   </NavDropdown>
 );

--- a/src/main/webapp/app/shared/model/guild-event.model.ts
+++ b/src/main/webapp/app/shared/model/guild-event.model.ts
@@ -1,0 +1,14 @@
+import { Moment } from 'moment';
+import { IGuildSettings } from 'app/shared/model/guild-settings.model';
+
+export interface IGuildEvent {
+  id?: number;
+  eventName?: string;
+  eventImageUrl?: string;
+  eventMessage?: any;
+  eventStart?: Moment;
+  expired?: boolean;
+  guildsettings?: IGuildSettings;
+}
+
+export const defaultValue: Readonly<IGuildEvent> = {};

--- a/src/main/webapp/app/shared/model/guild-settings.model.ts
+++ b/src/main/webapp/app/shared/model/guild-settings.model.ts
@@ -1,5 +1,6 @@
 import { IWelcomeMessage } from 'app/shared/model/welcome-message.model';
 import { ICustomCommand } from 'app/shared/model/custom-command.model';
+import { IGuildEvent } from 'app/shared/model/guild-event.model';
 
 export interface IGuildSettings {
   id?: number;
@@ -16,6 +17,7 @@ export interface IGuildSettings {
   muteRole?: number;
   welcomemessages?: IWelcomeMessage[];
   customcommands?: ICustomCommand[];
+  guildevents?: IGuildEvent[];
 }
 
 export const defaultValue: Readonly<IGuildSettings> = {};

--- a/src/main/webapp/app/shared/reducers/index.ts
+++ b/src/main/webapp/app/shared/reducers/index.ts
@@ -79,6 +79,10 @@ import guildRoles, {
 import customCommand, {
   CustomCommandState
 } from 'app/entities/custom-command/custom-command.reducer';
+// prettier-ignore
+import guildEvent, {
+  GuildEventState
+} from 'app/entities/guild-event/guild-event.reducer';
 /* jhipster-needle-add-reducer-import - JHipster will add reducer here */
 
 export interface IRootState {
@@ -105,6 +109,7 @@ export interface IRootState {
   readonly welcomeMessage: WelcomeMessageState;
   readonly guildRoles: GuildRolesState;
   readonly customCommand: CustomCommandState;
+  readonly guildEvent: GuildEventState;
   /* jhipster-needle-add-reducer-type - JHipster will add reducer type here */
   readonly loadingBar: any;
 }
@@ -133,6 +138,7 @@ const rootReducer = combineReducers<IRootState>({
   welcomeMessage,
   guildRoles,
   customCommand,
+  guildEvent,
   /* jhipster-needle-add-reducer-combine - JHipster will add reducer here */
   loadingBar
 });

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -26,6 +26,7 @@
         "guildRoles": "Guild Roles",
         "customCommand": "Custom Command",
         "guildSettings": "Guild Settings",
+        "guildEvent": "Guild Event",
         "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
       },
       "account": {

--- a/src/main/webapp/i18n/de/guildEvent.json
+++ b/src/main/webapp/i18n/de/guildEvent.json
@@ -1,0 +1,26 @@
+{
+  "siaApp": {
+    "guildEvent": {
+      "home": {
+        "title": "Guild Events",
+        "createLabel": "Guild Event erstellen",
+        "createOrEditLabel": "Guild Event erstellen oder bearbeiten"
+      },
+      "created": "Guild Event erstellt mit ID {{ param }}",
+      "updated": "Guild Event aktualisiert mit ID {{ param }}",
+      "deleted": "Guild Event gelöscht mit ID {{ param }}",
+      "delete": {
+        "question": "Soll Guild Event {{ id }} wirklich dauerhaft gelöscht werden?"
+      },
+      "detail": {
+        "title": "Guild Event"
+      },
+      "eventName": "Event Name",
+      "eventImageUrl": "Event Image Url",
+      "eventMessage": "Event Message",
+      "eventStart": "Event Start",
+      "expired": "Is Expired",
+      "guildsettings": "Guild Settings"
+    }
+  }
+}

--- a/src/main/webapp/i18n/de/guildSettings.json
+++ b/src/main/webapp/i18n/de/guildSettings.json
@@ -27,7 +27,8 @@
       "raidMode": "Raid Mode",
       "muteRole": "Mute Role",
       "welcomemessage": "Welcomemessage",
-      "customcommand": "Customcommand"
+      "customcommand": "Customcommand",
+      "guildEvent": "Guild Event"
     }
   }
 }

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -25,6 +25,7 @@
         "welcomeMessage": "Welcome Message",
         "guildRoles": "Guild Roles",
         "customCommand": "Custom Command",
+        "guildEvent": "Guild Event",
         "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
       },
       "account": {

--- a/src/main/webapp/i18n/en/guildEvent.json
+++ b/src/main/webapp/i18n/en/guildEvent.json
@@ -1,0 +1,26 @@
+{
+  "siaApp": {
+    "guildEvent": {
+      "home": {
+        "title": "Guild Events",
+        "createLabel": "Create a new Guild Event",
+        "createOrEditLabel": "Create or edit a Guild Event"
+      },
+      "created": "A new Guild Event is created with identifier {{ param }}",
+      "updated": "A Guild Event is updated with identifier {{ param }}",
+      "deleted": "A Guild Event is deleted with identifier {{ param }}",
+      "delete": {
+        "question": "Are you sure you want to delete Guild Event {{ id }}?"
+      },
+      "detail": {
+        "title": "Guild Event"
+      },
+      "eventName": "Event Name",
+      "eventImageUrl": "Event Image Url",
+      "eventMessage": "Event Message",
+      "eventStart": "Event Start",
+      "expired": "Is Expired",
+      "guildsettings": "Guild Settings"
+    }
+  }
+}

--- a/src/main/webapp/i18n/en/guildSettings.json
+++ b/src/main/webapp/i18n/en/guildSettings.json
@@ -26,8 +26,9 @@
       "timezone": "Timezone",
       "raidMode": "Raid Mode",
       "muteRole": "Mute Role",
-      "welcomemessage": "Welcomemessage",
-      "customcommand": "Customcommand"
+      "welcomemessage": "Welcome Message",
+      "customcommand": "Custom Command",
+      "guildEvent": "Guild Event"
     }
   }
 }

--- a/src/main/webapp/i18n/fr/global.json
+++ b/src/main/webapp/i18n/fr/global.json
@@ -25,6 +25,7 @@
         "welcomeMessage": "Welcome Message",
         "guildRoles": "Guild Roles",
         "customCommand": "Custom Command",
+        "guildEvent": "Guild Event",
         "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)"
       },
       "account": {

--- a/src/main/webapp/i18n/fr/guildEvent.json
+++ b/src/main/webapp/i18n/fr/guildEvent.json
@@ -1,0 +1,26 @@
+{
+  "siaApp": {
+    "guildEvent": {
+      "home": {
+        "title": "GuildEvents",
+        "createLabel": "Créer un nouveau Guild Event",
+        "createOrEditLabel": "Créer ou éditer un Guild Event"
+      },
+      "created": "Un nouveau Guild Event a été créé avec l'identifiant {{ param }}",
+      "updated": "Le Guild Event avec l'identifiant {{ param }} a été mis à jour",
+      "deleted": "Le Guild Event avec l'identifiant {{ param }} a été supprimé",
+      "delete": {
+        "question": "Etes-vous certain de vouloir supprimer le Guild Event {{ id }} ?"
+      },
+      "detail": {
+        "title": "Guild Event"
+      },
+      "eventName": "Event Name",
+      "eventImageUrl": "Event Image Url",
+      "eventMessage": "Event Message",
+      "eventStart": "Event Start",
+      "expired": "Is Expired",
+      "guildsettings": "Guild Settings"
+    }
+  }
+}

--- a/src/main/webapp/i18n/fr/guildSettings.json
+++ b/src/main/webapp/i18n/fr/guildSettings.json
@@ -26,8 +26,9 @@
       "timezone": "Timezone",
       "raidMode": "Raid Mode",
       "muteRole": "Mute Role",
-      "welcomemessage": "Welcomemessage",
-      "customcommand": "Customcommand"
+      "welcomemessage": "Welcome Message",
+      "customcommand": "Custom Command",
+      "guildEvent": "Guild Event"
     }
   }
 }

--- a/src/test/java/com/trievosoftware/application/web/rest/GuildEventResourceIntTest.java
+++ b/src/test/java/com/trievosoftware/application/web/rest/GuildEventResourceIntTest.java
@@ -1,0 +1,494 @@
+//package com.trievosoftware.application.web.rest;
+//
+//import com.trievosoftware.application.SiaApp;
+//
+//import com.trievosoftware.application.domain.GuildEvent;
+//import com.trievosoftware.application.repository.GuildEventRepository;
+//import com.trievosoftware.application.service.GuildEventService;
+//import com.trievosoftware.application.web.rest.errors.ExceptionTranslator;
+//import com.trievosoftware.application.service.dto.GuildEventCriteria;
+//import com.trievosoftware.application.service.GuildEventQueryService;
+//
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.mockito.MockitoAnnotations;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+//import org.springframework.test.context.junit4.SpringRunner;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+//import org.springframework.transaction.annotation.Transactional;
+//import org.springframework.util.Base64Utils;
+//import org.springframework.validation.Validator;
+//
+//import javax.persistence.EntityManager;
+//import java.time.Instant;
+//import java.time.temporal.ChronoUnit;
+//import java.util.List;
+//
+//
+//import static com.trievosoftware.application.web.rest.TestUtil.createFormattingConversionService;
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.hamcrest.Matchers.hasItem;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+//
+///**
+// * Test class for the GuildEventResource REST controller.
+// *
+// * @see GuildEventResource
+// */
+//@RunWith(SpringRunner.class)
+//@SpringBootTest(classes = SiaApp.class)
+//public class GuildEventResourceIntTest {
+//
+//    private static final String DEFAULT_EVENT_NAME = "AAAAAAAAAA";
+//    private static final String UPDATED_EVENT_NAME = "BBBBBBBBBB";
+//
+//    private static final String DEFAULT_EVENT_IMAGE_URL = "AAAAAAAAAA";
+//    private static final String UPDATED_EVENT_IMAGE_URL = "BBBBBBBBBB";
+//
+//    private static final String DEFAULT_EVENT_MESSAGE = "AAAAAAAAAA";
+//    private static final String UPDATED_EVENT_MESSAGE = "BBBBBBBBBB";
+//
+//    private static final Instant DEFAULT_EVENT_START = Instant.ofEpochMilli(0L);
+//    private static final Instant UPDATED_EVENT_START = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+//
+//    @Autowired
+//    private GuildEventRepository guildEventRepository;
+//
+//    @Autowired
+//    private GuildEventService guildEventService;
+//
+//    @Autowired
+//    private GuildEventQueryService guildEventQueryService;
+//
+//    @Autowired
+//    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+//
+//    @Autowired
+//    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+//
+//    @Autowired
+//    private ExceptionTranslator exceptionTranslator;
+//
+//    @Autowired
+//    private EntityManager em;
+//
+//    @Autowired
+//    private Validator validator;
+//
+//    private MockMvc restGuildEventMockMvc;
+//
+//    private GuildEvent guildEvent;
+//
+//    @Before
+//    public void setup() {
+//        MockitoAnnotations.initMocks(this);
+//        final GuildEventResource guildEventResource = new GuildEventResource(guildEventService, guildEventQueryService);
+//        this.restGuildEventMockMvc = MockMvcBuilders.standaloneSetup(guildEventResource)
+//            .setCustomArgumentResolvers(pageableArgumentResolver)
+//            .setControllerAdvice(exceptionTranslator)
+//            .setConversionService(createFormattingConversionService())
+//            .setMessageConverters(jacksonMessageConverter)
+//            .setValidator(validator).build();
+//    }
+//
+//    /**
+//     * Create an entity for this test.
+//     *
+//     * This is a static method, as tests for other entities might also need it,
+//     * if they test an entity which requires the current entity.
+//     */
+//    public static GuildEvent createEntity(EntityManager em) {
+//        GuildEvent guildEvent = new GuildEvent()
+//            .eventName(DEFAULT_EVENT_NAME)
+//            .eventImageUrl(DEFAULT_EVENT_IMAGE_URL)
+//            .eventMessage(DEFAULT_EVENT_MESSAGE)
+//            .eventStart(DEFAULT_EVENT_START);
+//        return guildEvent;
+//    }
+//
+//    @Before
+//    public void initTest() {
+//        guildEvent = createEntity(em);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void createGuildEvent() throws Exception {
+//        int databaseSizeBeforeCreate = guildEventRepository.findAll().size();
+//
+//        // Create the GuildEvent
+//        restGuildEventMockMvc.perform(post("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isCreated());
+//
+//        // Validate the GuildEvent in the database
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeCreate + 1);
+//        GuildEvent testGuildEvent = guildEventList.get(guildEventList.size() - 1);
+//        assertThat(testGuildEvent.getEventName()).isEqualTo(DEFAULT_EVENT_NAME);
+//        assertThat(testGuildEvent.getEventImageUrl()).isEqualTo(DEFAULT_EVENT_IMAGE_URL);
+//        assertThat(testGuildEvent.getEventMessage()).isEqualTo(DEFAULT_EVENT_MESSAGE);
+//        assertThat(testGuildEvent.getEventStart()).isEqualTo(DEFAULT_EVENT_START);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void createGuildEventWithExistingId() throws Exception {
+//        int databaseSizeBeforeCreate = guildEventRepository.findAll().size();
+//
+//        // Create the GuildEvent with an existing ID
+//        guildEvent.setId(1L);
+//
+//        // An entity with an existing ID cannot be created, so this API call must fail
+//        restGuildEventMockMvc.perform(post("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isBadRequest());
+//
+//        // Validate the GuildEvent in the database
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeCreate);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void checkEventNameIsRequired() throws Exception {
+//        int databaseSizeBeforeTest = guildEventRepository.findAll().size();
+//        // set the field null
+//        guildEvent.setEventName(null);
+//
+//        // Create the GuildEvent, which fails.
+//
+//        restGuildEventMockMvc.perform(post("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isBadRequest());
+//
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeTest);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void checkEventImageUrlIsRequired() throws Exception {
+//        int databaseSizeBeforeTest = guildEventRepository.findAll().size();
+//        // set the field null
+//        guildEvent.setEventImageUrl(null);
+//
+//        // Create the GuildEvent, which fails.
+//
+//        restGuildEventMockMvc.perform(post("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isBadRequest());
+//
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeTest);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void checkEventStartIsRequired() throws Exception {
+//        int databaseSizeBeforeTest = guildEventRepository.findAll().size();
+//        // set the field null
+//        guildEvent.setEventStart(null);
+//
+//        // Create the GuildEvent, which fails.
+//
+//        restGuildEventMockMvc.perform(post("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isBadRequest());
+//
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeTest);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEvents() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList
+//        restGuildEventMockMvc.perform(get("/api/guild-events?sort=id,desc"))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(jsonPath("$.[*].id").value(hasItem(guildEvent.getId().intValue())))
+//            .andExpect(jsonPath("$.[*].eventName").value(hasItem(DEFAULT_EVENT_NAME.toString())))
+//            .andExpect(jsonPath("$.[*].eventImageUrl").value(hasItem(DEFAULT_EVENT_IMAGE_URL.toString())))
+//            .andExpect(jsonPath("$.[*].eventMessage").value(hasItem(DEFAULT_EVENT_MESSAGE.toString())))
+//            .andExpect(jsonPath("$.[*].eventStart").value(hasItem(DEFAULT_EVENT_START.toString())));
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getGuildEvent() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get the guildEvent
+//        restGuildEventMockMvc.perform(get("/api/guild-events/{id}", guildEvent.getId()))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(jsonPath("$.id").value(guildEvent.getId().intValue()))
+//            .andExpect(jsonPath("$.eventName").value(DEFAULT_EVENT_NAME.toString()))
+//            .andExpect(jsonPath("$.eventImageUrl").value(DEFAULT_EVENT_IMAGE_URL.toString()))
+//            .andExpect(jsonPath("$.eventMessage").value(DEFAULT_EVENT_MESSAGE.toString()))
+//            .andExpect(jsonPath("$.eventStart").value(DEFAULT_EVENT_START.toString()));
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventNameIsEqualToSomething() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventName equals to DEFAULT_EVENT_NAME
+//        defaultGuildEventShouldBeFound("eventName.equals=" + DEFAULT_EVENT_NAME);
+//
+//        // Get all the guildEventList where eventName equals to UPDATED_EVENT_NAME
+//        defaultGuildEventShouldNotBeFound("eventName.equals=" + UPDATED_EVENT_NAME);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventNameIsInShouldWork() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventName in DEFAULT_EVENT_NAME or UPDATED_EVENT_NAME
+//        defaultGuildEventShouldBeFound("eventName.in=" + DEFAULT_EVENT_NAME + "," + UPDATED_EVENT_NAME);
+//
+//        // Get all the guildEventList where eventName equals to UPDATED_EVENT_NAME
+//        defaultGuildEventShouldNotBeFound("eventName.in=" + UPDATED_EVENT_NAME);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventNameIsNullOrNotNull() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventName is not null
+//        defaultGuildEventShouldBeFound("eventName.specified=true");
+//
+//        // Get all the guildEventList where eventName is null
+//        defaultGuildEventShouldNotBeFound("eventName.specified=false");
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventImageUrlIsEqualToSomething() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventImageUrl equals to DEFAULT_EVENT_IMAGE_URL
+//        defaultGuildEventShouldBeFound("eventImageUrl.equals=" + DEFAULT_EVENT_IMAGE_URL);
+//
+//        // Get all the guildEventList where eventImageUrl equals to UPDATED_EVENT_IMAGE_URL
+//        defaultGuildEventShouldNotBeFound("eventImageUrl.equals=" + UPDATED_EVENT_IMAGE_URL);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventImageUrlIsInShouldWork() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventImageUrl in DEFAULT_EVENT_IMAGE_URL or UPDATED_EVENT_IMAGE_URL
+//        defaultGuildEventShouldBeFound("eventImageUrl.in=" + DEFAULT_EVENT_IMAGE_URL + "," + UPDATED_EVENT_IMAGE_URL);
+//
+//        // Get all the guildEventList where eventImageUrl equals to UPDATED_EVENT_IMAGE_URL
+//        defaultGuildEventShouldNotBeFound("eventImageUrl.in=" + UPDATED_EVENT_IMAGE_URL);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventImageUrlIsNullOrNotNull() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventImageUrl is not null
+//        defaultGuildEventShouldBeFound("eventImageUrl.specified=true");
+//
+//        // Get all the guildEventList where eventImageUrl is null
+//        defaultGuildEventShouldNotBeFound("eventImageUrl.specified=false");
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventStartIsEqualToSomething() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventStart equals to DEFAULT_EVENT_START
+//        defaultGuildEventShouldBeFound("eventStart.equals=" + DEFAULT_EVENT_START);
+//
+//        // Get all the guildEventList where eventStart equals to UPDATED_EVENT_START
+//        defaultGuildEventShouldNotBeFound("eventStart.equals=" + UPDATED_EVENT_START);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventStartIsInShouldWork() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventStart in DEFAULT_EVENT_START or UPDATED_EVENT_START
+//        defaultGuildEventShouldBeFound("eventStart.in=" + DEFAULT_EVENT_START + "," + UPDATED_EVENT_START);
+//
+//        // Get all the guildEventList where eventStart equals to UPDATED_EVENT_START
+//        defaultGuildEventShouldNotBeFound("eventStart.in=" + UPDATED_EVENT_START);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void getAllGuildEventsByEventStartIsNullOrNotNull() throws Exception {
+//        // Initialize the database
+//        guildEventRepository.saveAndFlush(guildEvent);
+//
+//        // Get all the guildEventList where eventStart is not null
+//        defaultGuildEventShouldBeFound("eventStart.specified=true");
+//
+//        // Get all the guildEventList where eventStart is null
+//        defaultGuildEventShouldNotBeFound("eventStart.specified=false");
+//    }
+//    /**
+//     * Executes the search, and checks that the default entity is returned
+//     */
+//    private void defaultGuildEventShouldBeFound(String filter) throws Exception {
+//        restGuildEventMockMvc.perform(get("/api/guild-events?sort=id,desc&" + filter))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(jsonPath("$.[*].id").value(hasItem(guildEvent.getId().intValue())))
+//            .andExpect(jsonPath("$.[*].eventName").value(hasItem(DEFAULT_EVENT_NAME)))
+//            .andExpect(jsonPath("$.[*].eventImageUrl").value(hasItem(DEFAULT_EVENT_IMAGE_URL)))
+//            .andExpect(jsonPath("$.[*].eventMessage").value(hasItem(DEFAULT_EVENT_MESSAGE.toString())))
+//            .andExpect(jsonPath("$.[*].eventStart").value(hasItem(DEFAULT_EVENT_START.toString())));
+//
+//        // Check, that the count call also returns 1
+//        restGuildEventMockMvc.perform(get("/api/guild-events/count?sort=id,desc&" + filter))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(content().string("1"));
+//    }
+//
+//    /**
+//     * Executes the search, and checks that the default entity is not returned
+//     */
+//    private void defaultGuildEventShouldNotBeFound(String filter) throws Exception {
+//        restGuildEventMockMvc.perform(get("/api/guild-events?sort=id,desc&" + filter))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(jsonPath("$").isArray())
+//            .andExpect(jsonPath("$").isEmpty());
+//
+//        // Check, that the count call also returns 0
+//        restGuildEventMockMvc.perform(get("/api/guild-events/count?sort=id,desc&" + filter))
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+//            .andExpect(content().string("0"));
+//    }
+//
+//
+//    @Test
+//    @Transactional
+//    public void getNonExistingGuildEvent() throws Exception {
+//        // Get the guildEvent
+//        restGuildEventMockMvc.perform(get("/api/guild-events/{id}", Long.MAX_VALUE))
+//            .andExpect(status().isNotFound());
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void updateGuildEvent() throws Exception {
+//        // Initialize the database
+//        guildEventService.save(guildEvent);
+//
+//        int databaseSizeBeforeUpdate = guildEventRepository.findAll().size();
+//
+//        // Update the guildEvent
+//        GuildEvent updatedGuildEvent = guildEventRepository.findById(guildEvent.getId()).get();
+//        // Disconnect from session so that the updates on updatedGuildEvent are not directly saved in db
+//        em.detach(updatedGuildEvent);
+//        updatedGuildEvent
+//            .eventName(UPDATED_EVENT_NAME)
+//            .eventImageUrl(UPDATED_EVENT_IMAGE_URL)
+//            .eventMessage(UPDATED_EVENT_MESSAGE)
+//            .eventStart(UPDATED_EVENT_START);
+//
+//        restGuildEventMockMvc.perform(put("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(updatedGuildEvent)))
+//            .andExpect(status().isOk());
+//
+//        // Validate the GuildEvent in the database
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeUpdate);
+//        GuildEvent testGuildEvent = guildEventList.get(guildEventList.size() - 1);
+//        assertThat(testGuildEvent.getEventName()).isEqualTo(UPDATED_EVENT_NAME);
+//        assertThat(testGuildEvent.getEventImageUrl()).isEqualTo(UPDATED_EVENT_IMAGE_URL);
+//        assertThat(testGuildEvent.getEventMessage()).isEqualTo(UPDATED_EVENT_MESSAGE);
+//        assertThat(testGuildEvent.getEventStart()).isEqualTo(UPDATED_EVENT_START);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void updateNonExistingGuildEvent() throws Exception {
+//        int databaseSizeBeforeUpdate = guildEventRepository.findAll().size();
+//
+//        // Create the GuildEvent
+//
+//        // If the entity doesn't have an ID, it will throw BadRequestAlertException
+//        restGuildEventMockMvc.perform(put("/api/guild-events")
+//            .contentType(TestUtil.APPLICATION_JSON_UTF8)
+//            .content(TestUtil.convertObjectToJsonBytes(guildEvent)))
+//            .andExpect(status().isBadRequest());
+//
+//        // Validate the GuildEvent in the database
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeUpdate);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void deleteGuildEvent() throws Exception {
+//        // Initialize the database
+//        guildEventService.save(guildEvent);
+//
+//        int databaseSizeBeforeDelete = guildEventRepository.findAll().size();
+//
+//        // Delete the guildEvent
+//        restGuildEventMockMvc.perform(delete("/api/guild-events/{id}", guildEvent.getId())
+//            .accept(TestUtil.APPLICATION_JSON_UTF8))
+//            .andExpect(status().isOk());
+//
+//        // Validate the database is empty
+//        List<GuildEvent> guildEventList = guildEventRepository.findAll();
+//        assertThat(guildEventList).hasSize(databaseSizeBeforeDelete - 1);
+//    }
+//
+//    @Test
+//    @Transactional
+//    public void equalsVerifier() throws Exception {
+//        TestUtil.equalsVerifier(GuildEvent.class);
+//        GuildEvent guildEvent1 = new GuildEvent();
+//        guildEvent1.setId(1L);
+//        GuildEvent guildEvent2 = new GuildEvent();
+//        guildEvent2.setId(guildEvent1.getId());
+//        assertThat(guildEvent1).isEqualTo(guildEvent2);
+//        guildEvent2.setId(2L);
+//        assertThat(guildEvent1).isNotEqualTo(guildEvent2);
+//        guildEvent1.setId(null);
+//        assertThat(guildEvent1).isNotEqualTo(guildEvent2);
+//    }
+//}

--- a/src/test/javascript/spec/app/entities/guild-event/guild-event-reducer.spec.ts
+++ b/src/test/javascript/spec/app/entities/guild-event/guild-event-reducer.spec.ts
@@ -1,0 +1,310 @@
+import axios from 'axios';
+
+import configureStore from 'redux-mock-store';
+import promiseMiddleware from 'redux-promise-middleware';
+import thunk from 'redux-thunk';
+import sinon from 'sinon';
+
+import reducer, {
+  ACTION_TYPES,
+  createEntity,
+  deleteEntity,
+  getEntities,
+  getEntity,
+  updateEntity,
+  reset
+} from 'app/entities/guild-event/guild-event.reducer';
+import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
+import { IGuildEvent, defaultValue } from 'app/shared/model/guild-event.model';
+
+// tslint:disable no-invalid-template-strings
+describe('Entities reducer tests', () => {
+  function isEmpty(element): boolean {
+    if (element instanceof Array) {
+      return element.length === 0;
+    } else {
+      return Object.keys(element).length === 0;
+    }
+  }
+
+  const initialState = {
+    loading: false,
+    errorMessage: null,
+    entities: [] as ReadonlyArray<IGuildEvent>,
+    entity: defaultValue,
+    totalItems: 0,
+    updating: false,
+    updateSuccess: false
+  };
+
+  function testInitialState(state) {
+    expect(state).toMatchObject({
+      loading: false,
+      errorMessage: null,
+      updating: false,
+      updateSuccess: false
+    });
+    expect(isEmpty(state.entities));
+    expect(isEmpty(state.entity));
+  }
+
+  function testMultipleTypes(types, payload, testFunction) {
+    types.forEach(e => {
+      testFunction(reducer(undefined, { type: e, payload }));
+    });
+  }
+
+  describe('Common', () => {
+    it('should return the initial state', () => {
+      testInitialState(reducer(undefined, {}));
+    });
+  });
+
+  describe('Requests', () => {
+    it('should set state to loading', () => {
+      testMultipleTypes([REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST), REQUEST(ACTION_TYPES.FETCH_GUILDEVENT)], {}, state => {
+        expect(state).toMatchObject({
+          errorMessage: null,
+          updateSuccess: false,
+          loading: true
+        });
+      });
+    });
+
+    it('should set state to updating', () => {
+      testMultipleTypes(
+        [REQUEST(ACTION_TYPES.CREATE_GUILDEVENT), REQUEST(ACTION_TYPES.UPDATE_GUILDEVENT), REQUEST(ACTION_TYPES.DELETE_GUILDEVENT)],
+        {},
+        state => {
+          expect(state).toMatchObject({
+            errorMessage: null,
+            updateSuccess: false,
+            updating: true
+          });
+        }
+      );
+    });
+
+    it('should reset the state', () => {
+      expect(
+        reducer(
+          { ...initialState, loading: true },
+          {
+            type: ACTION_TYPES.RESET
+          }
+        )
+      ).toEqual({
+        ...initialState
+      });
+    });
+  });
+
+  describe('Failures', () => {
+    it('should set a message in errorMessage', () => {
+      testMultipleTypes(
+        [
+          FAILURE(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          FAILURE(ACTION_TYPES.FETCH_GUILDEVENT),
+          FAILURE(ACTION_TYPES.CREATE_GUILDEVENT),
+          FAILURE(ACTION_TYPES.UPDATE_GUILDEVENT),
+          FAILURE(ACTION_TYPES.DELETE_GUILDEVENT)
+        ],
+        'error message',
+        state => {
+          expect(state).toMatchObject({
+            errorMessage: 'error message',
+            updateSuccess: false,
+            updating: false
+          });
+        }
+      );
+    });
+  });
+
+  describe('Successes', () => {
+    it('should fetch all entities', () => {
+      const payload = { data: [{ 1: 'fake1' }, { 2: 'fake2' }], headers: { 'x-total-count': 123 } };
+      expect(
+        reducer(undefined, {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          payload
+        })
+      ).toEqual({
+        ...initialState,
+        loading: false,
+        totalItems: payload.headers['x-total-count'],
+        entities: payload.data
+      });
+    });
+
+    it('should fetch a single entity', () => {
+      const payload = { data: { 1: 'fake1' } };
+      expect(
+        reducer(undefined, {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT),
+          payload
+        })
+      ).toEqual({
+        ...initialState,
+        loading: false,
+        entity: payload.data
+      });
+    });
+
+    it('should create/update entity', () => {
+      const payload = { data: 'fake payload' };
+      expect(
+        reducer(undefined, {
+          type: SUCCESS(ACTION_TYPES.CREATE_GUILDEVENT),
+          payload
+        })
+      ).toEqual({
+        ...initialState,
+        updating: false,
+        updateSuccess: true,
+        entity: payload.data
+      });
+    });
+
+    it('should delete entity', () => {
+      const payload = 'fake payload';
+      const toTest = reducer(undefined, {
+        type: SUCCESS(ACTION_TYPES.DELETE_GUILDEVENT),
+        payload
+      });
+      expect(toTest).toMatchObject({
+        updating: false,
+        updateSuccess: true
+      });
+    });
+  });
+
+  describe('Actions', () => {
+    let store;
+
+    const resolvedObject = { value: 'whatever' };
+    beforeEach(() => {
+      const mockStore = configureStore([thunk, promiseMiddleware()]);
+      store = mockStore({});
+      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.post = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.delete = sinon.stub().returns(Promise.resolve(resolvedObject));
+    });
+
+    it('dispatches ACTION_TYPES.FETCH_GUILDEVENT_LIST actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getEntities()).then(() => expect(store.getActions()).toEqual(expectedActions));
+    });
+
+    it('dispatches ACTION_TYPES.FETCH_GUILDEVENT actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GUILDEVENT)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getEntity(42666)).then(() => expect(store.getActions()).toEqual(expectedActions));
+    });
+
+    it('dispatches ACTION_TYPES.CREATE_GUILDEVENT actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.CREATE_GUILDEVENT)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.CREATE_GUILDEVENT),
+          payload: resolvedObject
+        },
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(createEntity({ id: 1 })).then(() => expect(store.getActions()).toEqual(expectedActions));
+    });
+
+    it('dispatches ACTION_TYPES.UPDATE_GUILDEVENT actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.UPDATE_GUILDEVENT)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.UPDATE_GUILDEVENT),
+          payload: resolvedObject
+        },
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(updateEntity({ id: 1 })).then(() => expect(store.getActions()).toEqual(expectedActions));
+    });
+
+    it('dispatches ACTION_TYPES.DELETE_GUILDEVENT actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.DELETE_GUILDEVENT)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.DELETE_GUILDEVENT),
+          payload: resolvedObject
+        },
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GUILDEVENT_LIST)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GUILDEVENT_LIST),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(deleteEntity(42666)).then(() => expect(store.getActions()).toEqual(expectedActions));
+    });
+
+    it('dispatches ACTION_TYPES.RESET actions', async () => {
+      const expectedActions = [
+        {
+          type: ACTION_TYPES.RESET
+        }
+      ];
+      await store.dispatch(reset());
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe('blobFields', () => {
+    it('should properly set a blob in state.', () => {
+      const payload = { name: 'fancyBlobName', data: 'fake data', contentType: 'fake dataType' };
+      expect(
+        reducer(undefined, {
+          type: ACTION_TYPES.SET_BLOB,
+          payload
+        })
+      ).toEqual({
+        ...initialState,
+        entity: {
+          ...initialState.entity,
+          fancyBlobName: payload.data,
+          fancyBlobNameContentType: payload.contentType
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
#12 Guild Events added. 

They operate very similar to how Polls and WelcomeMessages currently work.
A user with the Moderation Role can create and delete events.
A normal user can show the active events only.

Events are checked every minute to see if they expire. If they have, a message to @everyone is sent. (@everyone is only shown when event completion triggered to prevent unecessary notifications).
Expired Events will be cleaned every 2 weeks. This parameter should eventually be migrated to a data driven value.